### PR TITLE
Fix a makeattributes crash when the UART isn't at 0x2...

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,11 @@ TESTS      += tests/e51-arty-openocd.bash
 TESTS      += tests/e51-arty-makeattributes.bash
 TESTS      += tests/e51-arty-mee_header.bash
 EXTRA_DIST += tests/e51-arty.dts
+TESTS      += tests/qemu-sifive_e-32-ldscript.bash
+TESTS      += tests/qemu-sifive_e-32-openocd.bash
+TESTS      += tests/qemu-sifive_e-32-makeattributes.bash
+TESTS      += tests/qemu-sifive_e-32-mee_header.bash
+EXTRA_DIST += tests/qemu-sifive_e-32.dts
 
 EXTRA_DIST += $(TESTS)
 

--- a/freedom-makeattributes-generator.c++
+++ b/freedom-makeattributes-generator.c++
@@ -162,6 +162,7 @@ static string get_dts_attribute (const string path, const string tag)
     const char *value;
 
     node = fdt_path_offset(dts_blob, path.c_str());
+    if (node < 0) return "";
     value = (const char *)fdt_getprop(dts_blob, node, tag.c_str(), &len);
     std::cout << string(value) << std::endl;
     return string(value);

--- a/tests/qemu-sifive_e-32-ldscript.bash
+++ b/tests/qemu-sifive_e-32-ldscript.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/qemu-sifive_e-32.dts -o qemu-sifive_e-32.dtb -O dtb
+$WORK_DIR/freedom-ldscript-generator -d qemu-sifive_e-32.dtb -l qemu-sifive_e-32.lds

--- a/tests/qemu-sifive_e-32-makeattributes.bash
+++ b/tests/qemu-sifive_e-32-makeattributes.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/qemu-sifive_e-32.dts -o qemu-sifive_e-32.dtb -O dtb
+$WORK_DIR/freedom-makeattributes-generator -d qemu-sifive_e-32.dtb -o qemu-sifive_e-32-build.env

--- a/tests/qemu-sifive_e-32-mee_header.bash
+++ b/tests/qemu-sifive_e-32-mee_header.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/qemu-sifive_e-32.dts -o qemu-sifive_e-32.dtb -O dtb
+$WORK_DIR/freedom-mee_header-generator -d qemu-sifive_e-32.dtb -o qemu-sifive_e-32-build.env

--- a/tests/qemu-sifive_e-32-openocd.bash
+++ b/tests/qemu-sifive_e-32-openocd.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/qemu-sifive_e-32.dts -o qemu-sifive_e-32.dtb -O dtb
+$WORK_DIR/freedom-openocdcfg-generator -b arty -d qemu-sifive_e-32.dtb -o qemu-sifive_e-32-openocd.cfg

--- a/tests/qemu-sifive_e-32.dts
+++ b/tests/qemu-sifive_e-32.dts
@@ -1,0 +1,140 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "SiFive,FE310G-dev", "fe310-dev", "sifive-dev";
+	model = "SiFive,FE310G";
+	L17: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		L6: cpu@0 {
+			clocks = <&refclk>;
+			compatible = "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <128>;
+			i-cache-size = <16384>;
+			next-level-cache = <&L12>;
+			reg = <0>;
+			riscv,isa = "rv32imac";
+			sifive,dtim = <&L5>;
+			sifive,itim = <&L4>;
+			status = "okay";
+			timebase-frequency = <1000000>;
+			L3: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L16: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "SiFive,FE310G-soc", "fe310-soc", "sifive-soc", "simple-bus";
+		ranges;
+		refclk: refclk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <66666666>;
+			clock-output-names = "refclk";
+		};
+		L1: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L3 3 &L3 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L2: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L3 65535>;
+			reg = <0x0 0x100>;
+			reg-names = "control";
+		};
+		maskrom@1000 {
+			reg = <0x1000 0x2000>;
+			reg-names = "mem";
+		};
+		otp@20000 {
+			reg = <0x20000 0x2000 0x10010000 0x1000>;
+			reg-names = "mem", "control";
+		};
+		aon@10000000 {
+			compatible = "sifive,aon0";
+			reg = <0x10000000 0x8000>;
+			reg-names = "mem";
+		};
+		prci@10008000 {
+			compatible = "sifive,prci0";
+			reg = <0x10008000 0x8000>;
+			reg-names = "mem";
+		};
+		L5: dtim@80000000 {
+			compatible = "sifive,dtim0";
+			reg = <0x80000000 0x4000>;
+			reg-names = "mem";
+		};
+		L8: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+			reg-names = "mem";
+		};
+		L9: global-external-interrupts {
+			interrupt-parent = <&L0>;
+			interrupts = <1 2 3 4>;
+		};
+		L13: gpio@10012000 {
+			compatible = "sifive,gpio0";
+			interrupt-parent = <&L0>;
+			interrupts = <7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22>;
+			reg = <0x10012000 0x1000>;
+			reg-names = "control";
+		};
+		L0: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L3 11>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <26>;
+		};
+		L4: itim@8000000 {
+			compatible = "sifive,itim0";
+			reg = <0x8000000 0x4000>;
+			reg-names = "mem";
+		};
+		L10: local-external-interrupts-0 {
+			interrupt-parent = <&L3>;
+			interrupts = <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31>;
+		};
+		L14: pwm@10015000 {
+			compatible = "sifive,pwm0";
+			interrupt-parent = <&L0>;
+			interrupts = <23 24 25 26>;
+			reg = <0x10015000 0x1000>;
+			reg-names = "control";
+		};
+		L11: serial@10013000 {
+			compatible = "sifive,uart0";
+			interrupt-parent = <&L0>;
+			interrupts = <5>;
+			reg = <0x10013000 0x1000>;
+			reg-names = "control";
+		};
+		L12: spi@10014000 {
+			compatible = "sifive,spi0";
+			interrupt-parent = <&L0>;
+			interrupts = <6>;
+			reg = <0x10014000 0x1000 0x20000000 0x20000000>;
+			reg-names = "control", "mem";
+		};
+		L7: teststatus@4000 {
+			compatible = "sifive,test0";
+			reg = <0x4000 0x1000>;
+			reg-names = "control";
+		};
+	};
+};


### PR DESCRIPTION
The attribute reading code didn't check for an error when looking for a
device tree node, which caused it to try to fetch a string at offset -1
which is invalid.  I've added a test DTS that demonstrates this issue,
along with tests that run it.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>