### PR TITLE
freedom-mee_header-generator: Handle multiple clocks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,8 @@ freedom_makeattributes_generator_SOURCES = \
 	freedom-makeattributes-generator.c++
 
 freedom_mee_header_generator_SOURCES = \
-	freedom-mee_header-generator.c++
+	freedom-mee_header-generator.c++ \
+	fdt.c++
 
 AM_TESTS_ENVIRONMENT = \
   export SOURCE_DIR=$(abspath $(srcdir)); \
@@ -40,7 +41,14 @@ TESTS      += tests/qemu-sifive_e-32-openocd.bash
 TESTS      += tests/qemu-sifive_e-32-makeattributes.bash
 TESTS      += tests/qemu-sifive_e-32-mee_header.bash
 EXTRA_DIST += tests/qemu-sifive_e-32.dts
+TESTS      += tests/hifive1-ldscript.bash
+TESTS      += tests/hifive1-openocd.bash
+TESTS      += tests/hifive1-makeattributes.bash
+TESTS      += tests/hifive1-mee_header.bash
+EXTRA_DIST += tests/hifive1.dts
 
 EXTRA_DIST += $(TESTS)
 
 EXTRA_DIST += README.md
+EXTRA_DIST += fdt.h++
+EXTRA_DIST += libfdt.h++

--- a/fdt.c++
+++ b/fdt.c++
@@ -1,0 +1,135 @@
+#include "fdt.h++"
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+#include <string>
+
+static uint8_t *read_fdt_from_path(const char *filename)
+{
+    uint8_t *buf = NULL;
+    int fd = 0; /* assume stdin */
+    size_t bufsize = 1024, offset =0;;
+    int ret = 0;
+
+    if (strcmp(filename, "-") != 0) {
+        fd = open(filename, O_RDONLY);
+        if (fd < 0)
+            return buf;
+    }
+
+    /* Loop until we have read everything */
+    buf = (uint8_t *)malloc(bufsize);
+    do {
+        /* Expand the buffer to hold the next chunk */
+        if (offset == bufsize) {
+            bufsize *= 2;
+            buf = (uint8_t *)realloc(buf, bufsize);
+        }
+
+        ret = read(fd, &buf[offset], bufsize - offset);
+        if (ret < 0) {
+            break;
+        }
+        offset += ret;
+    } while (ret != 0);
+
+    /* Clean up, including closing stdin; return errno on error */
+    close(fd);
+    if (ret) {
+        free(buf);
+        return NULL;
+    }
+    return buf;
+}
+
+void node::obtain_one(std::vector<node> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
+    std::vector<target_long> phandles;
+    obtain_one(phandles, buf, len, offset, consumed);
+    auto phandle_offset = fdt_node_offset_by_phandle(_dts_blob, phandles[0]);
+    v.push_back(node(_dts_blob, phandle_offset, -1));
+}
+
+void node::obtain_one(std::vector<target_long> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
+    uint32_t n = *((uint32_t *)(buf + offset));
+    v.push_back(ntohl(n));
+    *consumed = 4;
+}
+
+void node::obtain_one(std::vector<std::string> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
+    int i = offset;
+    while (i < len && buf[i] != '\0') {
+        ++i;
+    }
+    v.push_back(std::string((const char *)(buf + offset)));
+    *consumed = i+1;
+}
+
+std::string node::name(void) const
+{
+    auto node_name = fdt_get_name(_dts_blob, _offset, NULL);
+    if (node_name == nullptr)
+        return std::string();
+    return node_name;
+}
+
+std::string node::handle(void) const
+{
+    auto n = name();
+    std::transform(n.begin(), n.end(), n.begin(),
+                   [](unsigned char c) { return (c == '@') ? '_' : c; });
+    return n;
+}
+
+bool node::field_exists(std::string name) const
+{
+    int len;
+    auto out = fdt_get_property(_dts_blob, _offset, name.c_str(), &len);
+    return out != nullptr;
+}
+
+fdt::fdt(const char *path)
+: _dts_blob(read_fdt_from_path(path))
+{}
+
+fdt::fdt(std::string path)
+: _dts_blob(read_fdt_from_path(path.c_str()))
+{}
+
+bool fdt::path_exists(std::string path) const
+{
+    auto offset = fdt_path_offset(_dts_blob, path.c_str());
+    return offset > 0;
+}
+
+node fdt::node_by_path(std::string path) const
+{
+    auto offset = fdt_path_offset(_dts_blob, path.c_str());
+    return node(_dts_blob, offset, 0);
+}
+
+int fdt::match(const std::regex& r, std::function<void(const node&)> f) const
+{
+    int depth, offset;
+    int matches = 0;
+
+    depth = 0;
+    offset = fdt_path_offset(_dts_blob, "/");
+    while (offset >= 0 && depth >= 0) {
+        int compat_len;
+        auto compat_bytes = (const char *)fdt_getprop(_dts_blob, offset, "compatible", &compat_len);
+        if (compat_bytes != nullptr) {
+            for (int i = 0; i < compat_len; i += strlen(compat_bytes)) {
+                auto compat = std::string(&compat_bytes[i]);
+                if (compat.length() == 0 || !std::regex_match(compat, r))
+                    continue;
+                f(node(_dts_blob, offset, depth));
+                matches++;
+            }
+        }
+
+        offset = fdt_next_node(_dts_blob, offset, &depth);
+    }
+
+    return matches;
+}

--- a/fdt.h++
+++ b/fdt.h++
@@ -1,0 +1,232 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef FREEDOM_DEVICETREE_TOOLS_H
+#define FREEDOM_DEVICETREE_TOOLS_H
+
+#include "libfdt.h++"
+#include <stdint.h>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <tuple>
+
+class target_long {
+private:
+    const int64_t _value;
+
+public:
+    target_long()
+    : _value(-1)
+    {}
+
+    target_long(int64_t value)
+    : _value(value)
+    {}
+
+public:
+    std::string as_string(void) const { return std::to_string(_value); }
+
+    operator uint32_t() const { return _value; }
+};
+
+class node;
+
+template<typename func_t>
+void apply(func_t f) {
+    return f();
+};
+
+template<typename func_t, typename a_t>
+void apply(func_t f, std::tuple<a_t> t) {
+    return f(std::get<0>(t));
+}
+
+template<typename func_t, typename a_t, typename b_t>
+void apply(func_t f, std::tuple<a_t, b_t> t) {
+    return f(std::get<0>(t), std::get<1>(t));
+}
+
+template <typename... element_types>
+class tuple_t {
+public:
+    using tuple = std::tuple<element_types...>;
+};
+
+namespace std {
+    static inline std::string to_string(const target_long& tl) { return tl.as_string(); }
+}
+
+/* Represents a node within a device tree, which may point to other nodes. */
+class node {
+private:
+    const uint8_t *_dts_blob;
+    int _offset;
+    int _depth;
+
+public:
+    node(const uint8_t *dts_blob,
+         int offset,
+         int depth)
+    : _dts_blob(dts_blob),
+      _offset(offset),
+      _depth(depth)
+    {}
+
+    std::string name(void) const;
+
+    std::string handle(void) const;
+
+    bool field_exists(std::string) const;
+
+    void obtain_one(std::vector<node> &v, const uint8_t *buf, int len, int offset, int *consumed) const;
+    void obtain_one(std::vector<target_long> &v, const uint8_t *buf, int len, int offset, int *consumed) const;
+    void obtain_one(std::vector<std::string> &v, const uint8_t *buf, int len, int offset, int *consumed) const;
+    
+    template<typename a_t>
+    void obtain_one(std::vector<std::tuple<a_t>> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
+        int one_consumed;
+        *consumed = 0;
+    
+        std::vector<a_t> a_v;
+        obtain_one(a_v, buf, len, offset, &one_consumed);
+        offset += one_consumed;
+        *consumed += one_consumed;
+    
+        v.push_back(std::make_tuple(a_v[0]));
+    }
+    
+    template<typename a_t, typename b_t>
+    void obtain_one(std::vector<std::tuple<a_t, b_t>> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
+        int one_consumed;
+        *consumed = 0;
+    
+        std::vector<a_t> a_v;
+        obtain_one(a_v, buf, len, offset, &one_consumed);
+        offset += one_consumed;
+        *consumed += one_consumed;
+    
+        std::vector<b_t> b_v;
+        obtain_one(b_v, buf, len, offset, &one_consumed);
+        offset += one_consumed;
+        *consumed += one_consumed;
+    
+        v.push_back(std::make_tuple(a_v[0], b_v[0]));
+    }
+
+    template<typename t> t get_field(std::string name) const {
+        auto out = get_fields<t>(name);
+        if (out.size() == 0) {
+            std::cerr << "requested field \"" << name << "\" in node \"" << this->name() << ", but none found\n";
+            abort();
+        } else if (out.size() > 1) {
+            std::cerr << "requested field \"" << name << "\" in node \"" << this->name() << ", but multiple found\n";
+            abort();
+        }
+        return out[0];
+    }
+
+    template<typename t> std::vector<t> get_fields(std::string name) const {
+        int len;
+        auto buf = (const uint8_t *)fdt_getprop(_dts_blob, _offset, name.c_str(), &len);
+
+        if (buf == nullptr)
+            return std::vector<t>();
+
+        int i = 0;
+        auto out = std::vector<t>();
+        while (i < len) {
+            int consumed = -1;
+            obtain_one(out, buf, len, i, &consumed);
+            if (consumed == -1)
+                break;
+            i += consumed;
+        }
+        return out;
+    }
+
+    template<typename value_t, typename function_t>
+    int named_tuples(std::string key_name, std::string value_name,
+                     std::string key, value_t value, function_t function) const
+    {
+        auto keys = get_fields<std::string>(key_name);
+        auto vals = get_fields<typename value_t::tuple>(value_name);
+
+        int out = 0;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (keys[i].compare(key) == 0) {
+                out++;
+                apply(function, vals[i]);
+            }
+        }
+
+        return out;
+    }
+
+    template<typename value_t, typename function_t, typename... args_v>
+    int named_tuples(std::string key_name, std::string value_name,
+                     std::string key, value_t value, function_t function,
+                     args_v... args) const
+    {
+        return named_tuples(key_name, value_name, std::forward<args_v>(args)...)
+               + named_tuples(key_name, value_name, key, value, function);
+    }
+
+    template<typename zero_function_t, typename one_function_t, typename... args_v>
+    void maybe_tuple(std::string key, tuple_t<args_v...> value, zero_function_t zero_func, one_function_t one_func) const {
+        auto out = get_fields<std::tuple<args_v...>>(key);
+        if (out.size() == 0)
+            return apply(zero_func);
+        if (out.size() == 1)
+            return apply(one_func, out[0]);
+
+        std::cerr << "requested field \"" << key << "\" in node \"" << name() << "\", but multiple found\n";
+        abort();
+    }
+};
+
+/* Represents a single FDT, which is read in as a binary from a file. */
+class fdt {
+private:
+    const uint8_t *_dts_blob;
+
+public:
+    fdt(const char *path);
+    fdt(const std::string path);
+
+    ~fdt(void) { delete _dts_blob; }
+
+    bool path_exists(std::string) const;
+    node node_by_path(std::string) const;
+
+    template <typename... args>
+    int match(const std::regex& r, std::function<void(const node&)> f, args... a) const
+    {
+        return match(r, f) + match(std::forward<args>(a)...);
+    }
+
+    int match(const std::regex& r, std::function<void(const node&)> f) const;
+
+    template <typename... tuple_args, typename... args, typename func>
+    int chosen(std::string r, tuple_t<tuple_args...> types, func f, args... a) const
+    {
+        return chosen(r, types, f) + chosen(std::forward<args>(a)...);
+    }
+
+    template <typename... tuple_args, typename... args, typename func>
+    int chosen(std::string r, tuple_t<tuple_args...> types, func f) const
+    {
+        if (path_exists("/chosen") == false)
+            return 0;
+
+        auto n = node_by_path("/chosen");
+        if (n.field_exists(r) == false)
+            return 0;
+
+        auto t = n.get_field<std::tuple<tuple_args...>>(r);
+        apply(f, t);
+        return 1;
+    }
+};
+
+#endif

--- a/libfdt.h++
+++ b/libfdt.h++
@@ -1,0 +1,7 @@
+#ifdef __cplusplus
+extern "C" {
+# include <libfdt.h>
+};
+#else
+# include <libfdt.h>
+#endif

--- a/tests/hifive1-ldscript.bash
+++ b/tests/hifive1-ldscript.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/hifive1.dts -o hifive1.dtb -O dtb
+$WORK_DIR/freedom-ldscript-generator -d hifive1.dtb -l hifive1.lds

--- a/tests/hifive1-makeattributes.bash
+++ b/tests/hifive1-makeattributes.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/hifive1.dts -o hifive1.dtb -O dtb
+$WORK_DIR/freedom-makeattributes-generator -d hifive1.dtb -o hifive1-build.env

--- a/tests/hifive1-mee_header.bash
+++ b/tests/hifive1-mee_header.bash
@@ -1,0 +1,9 @@
+set -ex
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/hifive1.dts -o hifive1.dtb -O dtb
+$WORK_DIR/freedom-mee_header-generator -d hifive1.dtb -o hifive1-build.h

--- a/tests/hifive1-openocd.bash
+++ b/tests/hifive1-openocd.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/hifive1.dts -o hifive1.dtb -O dtb
+$WORK_DIR/freedom-openocdcfg-generator -b arty -d hifive1.dtb -o hifive1-openocd.cfg

--- a/tests/hifive1.dts
+++ b/tests/hifive1.dts
@@ -1,0 +1,185 @@
+/dts-v1/;
+
+/ {
+        #address-cells = <1>;
+        #size-cells = <1>;
+        compatible = "sifive,hifive1";
+        model = "sifive,hifive1";
+
+        chosen {
+                stdout-path = "/soc/serial@10013000:115200";
+                mee,entry = <&sip0 0x400000>;
+        };
+
+        cpus {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                compatible = "sifive,fe310-g000";
+                L6: cpu@0 {
+                        clocks = <&hfclk>;
+                        compatible = "sifive,rocket0", "riscv";
+                        device_type = "cpu";
+                        i-cache-block-size = <64>;
+                        i-cache-sets = <128>;
+                        i-cache-size = <16384>;
+                        next-level-cache = <&sip0>;
+                        reg = <0>;
+                        riscv,isa = "rv32imac";
+                        sifive,dtim = <&dtim>;
+                        sifive,itim = <&itim>;
+                        status = "okay";
+                        timebase-frequency = <1000000>;
+                        hlic: interrupt-controller {
+                                #interrupt-cells = <1>;
+                                compatible = "riscv,cpu-intc";
+                                interrupt-controller;
+                        };
+                };
+        };
+
+        soc {
+                #address-cells = <1>;
+                #size-cells = <1>;
+                #clock-cells = <1>;
+                compatible = "sifive,hifive1";
+                ranges;
+
+                hfxoscin: clock@0 {
+                        #clock-cells = <0>;
+                        compatible = "fixed-clock";
+                        clock-frequency = <16000000>;
+                };
+                hfxoscout: clock@1 {
+                        compatible = "sifive,fe310-g000,hfxosc";
+                        clocks = <&hfxoscin>;
+                        reg = <&prci 0x4>;
+                        reg-names = "config";
+                };
+                hfroscin: clock@2 {
+                        #clock-cells = <0>;
+                        compatible = "fixed-clock";
+                        clock-frequency = <72000000>;
+                };
+                hfroscout: clock@3 {
+                        compatible = "sifive,fe310-g000,hfrosc";
+                        clocks = <&hfroscin>;
+                        reg = <&prci 0x0>;
+                        reg-names = "config";
+                };
+                hfclk: clock@4 {
+                        compatible = "sifive,fe310-g000,pll";
+                        clocks = <&hfxoscout &hfroscout>;
+                        clock-names = "pllref", "pllsel0";
+                        reg = <&prci 0x8 &prci 0xc>;
+                        reg-names = "config", "divider";
+                };
+
+                lfroscin: clock@5 {
+                        #clock-cells = <0>;
+                        compatible = "fixed-clock";
+                        clock-frequency = <32000000>;
+                };
+                lfclk: clock@6 {
+                        compatible = "sifive,fe310-g000,lfrosc";
+                        clocks = <&lfroscin>;
+                        reg = <&aon 0x70>;
+                        reg-names = "config";
+                };
+
+                aon: aon@10000000 {
+                        compatible = "sifive,aon0";
+                        reg = <0x10000000 0x8000>;
+                        reg-names = "mem";
+                };
+
+                prci: prci@10008000 {
+                        compatible = "sifive,fe310-g000,prci";
+                        reg = <0x10008000 0x8000>;
+                        reg-names = "mem";
+                };
+
+                clint: clint@2000000 {
+                        compatible = "riscv,clint0";
+                        interrupts-extended = <&hlic 3 &hlic 7>;
+                        reg = <0x2000000 0x10000>;
+                        reg-names = "control";
+                };
+                local-external-interrupts-0 {
+                        compatible = "sifive,local-external-interrupts0";
+                        interrupt-parent = <&hlic>;
+                        interrupts = <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31>;
+                };
+                plic: interrupt-controller@c000000 {
+                        #interrupt-cells = <1>;
+                        compatible = "riscv,plic0";
+                        interrupt-controller;
+                        interrupts-extended = <&hlic 11>;
+                        reg = <0xc000000 0x4000000>;
+                        reg-names = "control";
+                        riscv,max-priority = <7>;
+                        riscv,ndev = <26>;
+                };
+                global-external-interrupts {
+                        compatile = "sifive,global-external-interrupts0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <1 2 3 4>;
+                };
+
+                debug-controller@0 {
+                        compatible = "sifive,debug-011", "riscv,debug-011";
+                        interrupts-extended = <&hlic 65535>;
+                        reg = <0x0 0x100>;
+                        reg-names = "control";
+                };
+
+                maskrom@1000 {
+                        reg = <0x1000 0x2000>;
+                        reg-names = "mem";
+                };
+                otp@20000 {
+                        reg = <0x20000 0x2000 0x10010000 0x1000>;
+                        reg-names = "mem", "control";
+                };
+
+                dtim: dtim@80000000 {
+                        compatible = "sifive,dtim0";
+                        reg = <0x80000000 0x4000>;
+                        reg-names = "mem";
+                };
+                itim: itim@8000000 {
+                        compatible = "sifive,itim0";
+                        reg = <0x8000000 0x4000>;
+                        reg-names = "mem";
+                };
+
+                pwm@10015000 {
+                        compatible = "sifive,pwm0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <23 24 25 26>;
+                        reg = <0x10015000 0x1000>;
+                        reg-names = "control";
+                };
+                gpio@10012000 {
+                        compatible = "sifive,gpio0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22>;
+                        reg = <0x10012000 0x1000>;
+                        reg-names = "control";
+                };
+                uart0: serial@10013000 {
+                        compatible = "sifive,uart0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <5>;
+                        reg = <0x10013000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                };
+                sip0: spi@10014000 {
+                        compatible = "sifive,spi0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <6>;
+                        reg = <0x10014000 0x1000 0x20000000 0x20000000>;
+                        reg-names = "control", "mem";
+                };
+        };
+};


### PR DESCRIPTION
The HiFive1 has a more complicated clocking system that the QEMU and
FPGA targets do.  This commit allows the MEE header file generator to
generate enough information to inform the MEE about these nested
clocking systems.

The actual generated output is now very tightly coupled to the MEE
implementation, which isn't ideal.  I'm not sure quite how else to deal
with this, though.

There's an additional test set that targets the HiFive1 device tree that
we're actually going to send out (or at least, close to it).

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>