### PR TITLE
Add support for RTL emulation machines

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,11 @@ TESTS      += tests/hifive1-openocd.bash
 TESTS      += tests/hifive1-makeattributes.bash
 TESTS      += tests/hifive1-mee_header.bash
 EXTRA_DIST += tests/hifive1.dts
+TESTS      += tests/e31-eval-ldscript.bash
+TESTS      += tests/e31-eval-openocd.bash
+TESTS      += tests/e31-eval-makeattributes.bash
+TESTS      += tests/e31-eval-mee_header.bash
+EXTRA_DIST += tests/e31-eval.dts
 
 EXTRA_DIST += $(TESTS)
 

--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -189,6 +189,7 @@ static void dts_memory (void)
     }
     alias_memory("dtim", "ram");
     alias_memory("spi", "flash");
+    alias_memory("testram", "flash");
 }
 
 static void show_dts_memory (string mtype)
@@ -224,7 +225,8 @@ static void write_linker_memory (fstream &os, bool scratchpad)
       if (!scratchpad &&
 	  (entry.mem_type.compare("mem") == 0) &&
 	  (entry.mem_alias.compare("flash") == 0)) {
-	flash_offset = 0x400000;
+        if (entry.mem_name.compare("spi") == 0)
+	  flash_offset = 0x400000;
 	os << "\t" << entry.mem_alias <<  " (rxai!w)";
       } else if (entry.mem_alias.compare("ram") == 0) {
 	os << "\t" << entry.mem_alias <<  " (wxa!ri)";

--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -240,13 +240,16 @@ static void write_linker_memory (fstream &os, bool scratchpad)
     os << "}" << std::endl << std::endl;
 }
 
-static void write_linker_phdrs (fstream &os)
+static void write_linker_phdrs (fstream &os, bool scratchpad)
 {
   //os << "#" << __FUNCTION__ << std::endl;
     os << "PHDRS" << std::endl << "{" << std::endl;
     os << "\tflash PT_LOAD;" << std::endl;
     os << "\tram_init PT_LOAD;" << std::endl;
-    os << "\tram PT_NULL;" << std::endl;
+    if (scratchpad == false)
+        os << "\tram PT_NULL;" << std::endl;
+    else
+        os << "\tram PT_LOAD;" << std::endl;
     os << "}" << std::endl << std::endl;
 }
 
@@ -607,6 +610,9 @@ int main (int argc, char* argv[])
   get_dts_attribute("/cpus/cpu@0", "riscv,isa");
   dts_memory();
 
+  if (has_memory("spi") == 0 && has_memory("testram"))
+    scratchpad = true;
+
   if (!linker_file.empty()) {
     std::fstream lds;
 
@@ -618,7 +624,7 @@ int main (int argc, char* argv[])
 
     write_linker_file(lds);
     write_linker_memory(lds, scratchpad);
-    write_linker_phdrs(lds);
+    write_linker_phdrs(lds, scratchpad);
     write_linker_sections(lds, scratchpad, ramrodata);
   }
 

--- a/freedom-mee_header-generator.c++
+++ b/freedom-mee_header-generator.c++
@@ -98,7 +98,8 @@ static void write_config_file(const fdt &dtb, fstream &os)
     std::regex("sifive,fe310-g000,prci"),   [&](node n) { emit_include("sifive,fe310-g000,prci");   },
     std::regex("sifive,fe310-g000,hfxosc"), [&](node n) { emit_include("sifive,fe310-g000,hfxosc"); },
     std::regex("sifive,fe310-g000,hfrosc"), [&](node n) { emit_include("sifive,fe310-g000,hfrosc"); },
-    std::regex("sifive,uart0"),             [&](node n) { emit_include("sifive,uart0");             }
+    std::regex("sifive,uart0"),             [&](node n) { emit_include("sifive,uart0");             },
+    std::regex("sifive,test0"),             [&](node n) { emit_include("sifive,test0");             }
   );
 
   /* Now emit the various nodes's header definitons. */
@@ -108,7 +109,8 @@ static void write_config_file(const fdt &dtb, fstream &os)
     std::regex("sifive,fe310-g000,prci"),   [&](node n) { emit_struct_decl("sifive_fe310_g000_prci",   n); },
     std::regex("sifive,fe310-g000,hfxosc"), [&](node n) { emit_struct_decl("sifive_fe310_g000_hfxosc", n); },
     std::regex("sifive,fe310-g000,hfrosc"), [&](node n) { emit_struct_decl("sifive_fe310_g000_hfrosc", n); },
-    std::regex("sifive,uart0"),             [&](node n) { emit_struct_decl("sifive_uart0",             n); }
+    std::regex("sifive,uart0"),             [&](node n) { emit_struct_decl("sifive_uart0",             n); },
+    std::regex("sifive,test0"),             [&](node n) { emit_struct_decl("sifive_test0",             n); }
   );
 
   /* Walk through the device tree, emitting various nodes as we know about
@@ -192,6 +194,18 @@ static void write_config_file(const fdt &dtb, fstream &os)
         [&](){ emit_struct_field_null("clock"); },
         [&](node n) { emit_struct_field_node("clock", n, ".clock"); });
       emit_struct_end();
+    }, std::regex("sifive,test0"), [&](node n) {
+      emit_struct_begin("sifive_test0", n);
+      emit_struct_field("vtable", "&__mee_driver_vtable_sifive_test0");
+      emit_struct_field("shutdown.vtable", "&__mee_driver_vtable_sifive_test0.shutdown");
+      n.named_tuples(
+        "reg-names", "reg",
+        "control", tuple_t<target_long, target_long>(), [&](target_long base, target_long size) {
+          emit_struct_field_tl("base", base);
+          emit_struct_field_tl("size", size);
+        });
+      emit_struct_end();
+      emit_def_handle("__MEE_DT_SHUTDOWN_HANDLE", n, ".shutdown");
     }
   );
 

--- a/tests/e31-eval-ldscript.bash
+++ b/tests/e31-eval-ldscript.bash
@@ -1,0 +1,22 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-eval.dts -o e31-eval.dtb -O dtb
+$WORK_DIR/freedom-ldscript-generator -d e31-eval.dtb -l e31-eval.lds
+
+cat e31-eval.lds
+if [[ "$(grep ">flash" e31-eval.lds | wc -l)" == 0 ]]
+then
+    echo "The E31 eval config must load code into the ahb-periph-port" >&2
+    exit 1
+fi
+
+if [[ "$(grep "flash (rxai!w) : ORIGIN = 0x20000000, LENGTH = 0x2000" e31-eval.lds | wc -l)" == 0 ]]
+then
+    echo "The E31 eval config must load code into the test RAM next to the AHB periph port" >&2
+    exit 1
+fi

--- a/tests/e31-eval-makeattributes.bash
+++ b/tests/e31-eval-makeattributes.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-eval.dts -o e31-eval.dtb -O dtb
+$WORK_DIR/freedom-makeattributes-generator -d e31-eval.dtb -o e31-eval-build.env

--- a/tests/e31-eval-mee_header.bash
+++ b/tests/e31-eval-mee_header.bash
@@ -1,0 +1,16 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-eval.dts -o e31-eval.dtb -O dtb
+$WORK_DIR/freedom-mee_header-generator -d e31-eval.dtb -o e31-eval.h
+
+cat e31-eval.h
+if [[ "$(grep "struct __mee_driver_sifive_test0" e31-eval.h | wc -l)" == 0 ]]
+then
+    echo "The E31 evaluation config has a test finisher that must be used, as otherwise the RTL test harness will take forever to run." >&2
+    exit 1
+fi

--- a/tests/e31-eval-openocd.bash
+++ b/tests/e31-eval-openocd.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-eval.dts -o e31-eval.dtb -O dtb
+$WORK_DIR/freedom-openocdcfg-generator -b arty -d e31-eval.dtb -o e31-eval-openocd.cfg

--- a/tests/e31-eval.dts
+++ b/tests/e31-eval.dts
@@ -1,0 +1,105 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "SiFive,FE310G-dev", "fe310-dev", "sifive-dev";
+	model = "SiFive,FE310G";
+	L15: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		L6: cpu@0 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <128>;
+			i-cache-size = <16384>;
+			reg = <0>;
+			riscv,isa = "rv32imac";
+			sifive,dtim = <&L5>;
+			sifive,itim = <&L4>;
+			status = "okay";
+			timebase-frequency = <1000000>;
+			L3: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L14: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "SiFive,FE310G-soc", "fe310-soc", "sifive-soc", "simple-bus";
+		ranges;
+		L12: ahb-periph-port@20000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "simple-bus";
+			ranges = <0x20000000 0x20000000 0x2000>;
+		};
+		L11: ahb-sys-port@40000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "simple-bus";
+			ranges = <0x40000000 0x40000000 0x2000>;
+		};
+		L1: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L3 3 &L3 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L2: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L3 65535>;
+			reg = <0x0 0x1000>;
+			reg-names = "control";
+		};
+		L5: dtim@80000000 {
+			compatible = "sifive,dtim0";
+			reg = <0x80000000 0x4000>;
+			reg-names = "mem";
+		};
+		L8: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+			reg-names = "mem";
+		};
+		L9: global-external-interrupts {
+			interrupt-parent = <&L0>;
+			interrupts = <1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127>;
+		};
+		L0: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L3 11>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <127>;
+		};
+		L4: itim@8000000 {
+			compatible = "sifive,itim0";
+			reg = <0x8000000 0x4000>;
+			reg-names = "mem";
+		};
+		L10: local-external-interrupts-0 {
+			interrupt-parent = <&L3>;
+			interrupts = <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31>;
+		};
+		L7: teststatus@4000 {
+			compatible = "sifive,test0";
+			reg = <0x4000 0x1000>;
+			reg-names = "control";
+		};
+		test_memory: testram@20000000 {
+			compatible = "sifive,testram0";
+			reg = <0x20000000 0x2000>;
+			reg-names = "mem";
+			word-size-bytes = <4>;
+		};
+	};
+};


### PR DESCRIPTION
The simulation RTL targets have slightly different behavior than the ASICs:

* There's no emulated SPI flash, instead there's a magic memory.
* There's a quick test finisher to get some simple data out of the simulation about the correctness of a given test.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>