### PR TITLE
Support designs with 64-bit addresses or sizes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,8 @@ bin_PROGRAMS =  freedom-ldscript-generator \
 		freedom-mee_header-generator
 
 freedom_ldscript_generator_SOURCES = \
-	freedom-ldscript-generator.c++
+	freedom-ldscript-generator.c++ \
+	fdt.c++
 
 freedom_openocdcfg_generator_SOURCES = \
 	freedom-openocdcfg-generator.c++

--- a/fdt.c++
+++ b/fdt.c++
@@ -2,6 +2,7 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <cassert>
 #include <cstring>
 #include <string>
 
@@ -43,17 +44,81 @@ static uint8_t *read_fdt_from_path(const char *filename)
     return buf;
 }
 
+node node::parent(void) const
+{
+    auto parent_offset = fdt_parent_offset(_dts_blob, _offset);
+    return node(_dts_blob, parent_offset, _depth-1);
+}
+
+int node::num_addr_cells(void) const
+{
+    auto f = parent().get_fields<uint32_t>("#address-cells");
+    if (f.size() == 0)
+        return 2;
+    if (f.size() == 1)
+        return f[0];
+
+    std::cerr << "#address-cells has more than one cell\n";
+    abort();
+}
+
+int node::num_size_cells(void) const
+{
+    auto f = parent().get_fields<uint32_t>("#size-cells");
+    if (f.size() == 0)
+        return 2;
+    if (f.size() == 1)
+        return f[0];
+
+    std::cerr << "#size-cells has more than one cell\n";
+    abort();
+}
+
 void node::obtain_one(std::vector<node> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
-    std::vector<target_long> phandles;
+    std::vector<uint32_t> phandles;
     obtain_one(phandles, buf, len, offset, consumed);
     auto phandle_offset = fdt_node_offset_by_phandle(_dts_blob, phandles[0]);
     v.push_back(node(_dts_blob, phandle_offset, -1));
 }
 
-void node::obtain_one(std::vector<target_long> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
+void node::obtain_one(std::vector<uint32_t> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
     uint32_t n = *((uint32_t *)(buf + offset));
     v.push_back(ntohl(n));
     *consumed = 4;
+}
+
+void node::obtain_one(std::vector<target_addr> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
+    auto n = ((uint32_t *)(buf + offset));
+    switch (num_addr_cells()) {
+    case 1:
+        v.push_back(ntohl(n[0]));
+        *consumed = 4;
+        return;
+    case 2:
+        v.push_back(ntohl(n[1]) | ((uint64_t)(ntohl(n[0])) << 32));
+        *consumed = 8;
+        return;
+    }
+
+    std::cerr << "Unknown number of address cells\n";
+    abort();
+}
+
+void node::obtain_one(std::vector<target_size> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
+    auto n = ((uint32_t *)(buf + offset));
+    switch (num_size_cells()) {
+    case 1:
+        v.push_back(ntohl(n[0]));
+        *consumed = 4;
+        return;
+    case 2:
+        v.push_back(ntohl(n[1]) | ((uint64_t)(ntohl(n[0])) << 32));
+        *consumed = 8;
+        return;
+    }
+
+    std::cerr << "Unknown number of address cells\n";
+    abort();
 }
 
 void node::obtain_one(std::vector<std::string> &v, const uint8_t *buf, int len, int offset, int *consumed) const {
@@ -88,13 +153,22 @@ bool node::field_exists(std::string name) const
     return out != nullptr;
 }
 
-fdt::fdt(const char *path)
-: _dts_blob(read_fdt_from_path(path))
-{}
+
+
+fdt::fdt(const uint8_t *blob)
+: _dts_blob(blob),
+  _allocated(false)
+{
+    assert(blob != nullptr);
+    assert(_dts_blob != nullptr);
+}
 
 fdt::fdt(std::string path)
-: _dts_blob(read_fdt_from_path(path.c_str()))
-{}
+: _dts_blob(read_fdt_from_path(path.c_str())),
+  _allocated(true)
+{
+    assert(_dts_blob != nullptr);
+}
 
 bool fdt::path_exists(std::string path) const
 {

--- a/freedom-mee_header-generator.c++
+++ b/freedom-mee_header-generator.c++
@@ -81,7 +81,15 @@ static void write_config_file(const fdt &dtb, fstream &os)
     os << "    ." << field << " = NULL,\n";
   };
 
-  auto emit_struct_field_tl = [&](std::string field, target_long value) {
+  auto emit_struct_field_u32 = [&](std::string field, uint32_t value) {
+    os << "    ." << field << " = " << std::to_string(value) << "UL,\n";
+  };
+
+  auto emit_struct_field_ta = [&](std::string field, target_addr value) {
+    os << "    ." << field << " = " << std::to_string(value) << "UL,\n";
+  };
+
+  auto emit_struct_field_ts = [&](std::string field, target_size value) {
     os << "    ." << field << " = " << std::to_string(value) << "UL,\n";
   };
 
@@ -126,7 +134,7 @@ static void write_config_file(const fdt &dtb, fstream &os)
       emit_struct_begin("fixed_clock", n);
       emit_struct_field("vtable", "&__mee_driver_vtable_fixed_clock");
       emit_struct_field("clock.vtable", "&__mee_driver_vtable_fixed_clock.clock");
-      emit_struct_field_tl("rate", n.get_field<target_long>("clock-frequency"));
+      emit_struct_field_u32("rate", n.get_field<uint32_t>("clock-frequency"));
       emit_struct_end();
     }, std::regex("sifive,fe310-g000,pll"), [&](node n) {
       emit_struct_begin("sifive_fe310_g000_pll", n);
@@ -142,13 +150,13 @@ static void write_config_file(const fdt &dtb, fstream &os)
         });
       n.named_tuples(
         "reg-names", "reg",
-        "config", tuple_t<node, target_long>(), [&](node base, target_long off) {
+        "config", tuple_t<node, target_size>(), [&](node base, target_size off) {
           emit_struct_field_node("config_base", base, "");
-          emit_struct_field_tl("config_offset", off);
+          emit_struct_field_ts("config_offset", off);
         },
-        "divider", tuple_t<node, target_long>(), [&](node base, target_long off) {
+        "divider", tuple_t<node, target_size>(), [&](node base, target_size off) {
           emit_struct_field_node("divider_base", base, "");
-          emit_struct_field_tl("divider_offset", off);
+          emit_struct_field_ts("divider_offset", off);
         });
       emit_struct_end();
     }, std::regex("sifive,fe310-g000,prci"), [&](node n) {
@@ -156,9 +164,9 @@ static void write_config_file(const fdt &dtb, fstream &os)
       emit_struct_field("vtable", "&__mee_driver_vtable_sifive_fe310_g000_prci");
       n.named_tuples(
         "reg-names", "reg",
-        "mem", tuple_t<target_long, target_long>(), [&](target_long base, target_long size) {
-          emit_struct_field_tl("base", base);
-          emit_struct_field_tl("size", size);
+        "mem", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
+          emit_struct_field_ta("base", base);
+          emit_struct_field_ts("size", size);
         });
       emit_struct_end();
     }, std::regex("sifive,fe310-g000,hfxosc"), [&](node n) {
@@ -168,9 +176,9 @@ static void write_config_file(const fdt &dtb, fstream &os)
       emit_struct_field_node("ref", n.get_field<node>("clocks"), ".clock");
       n.named_tuples(
         "reg-names", "reg",
-        "config", tuple_t<node, target_long>(), [&](node base, target_long offset) {
+        "config", tuple_t<node, target_size>(), [&](node base, target_size offset) {
           emit_struct_field_node("config_base", base, "");
-          emit_struct_field_tl("config_offset", offset);
+          emit_struct_field_ts("config_offset", offset);
         });
       emit_struct_end();
     }, std::regex("sifive,fe310-g000,hfrosc"), [&](node n) {
@@ -180,9 +188,9 @@ static void write_config_file(const fdt &dtb, fstream &os)
       emit_struct_field_node("ref", n.get_field<node>("clocks"), ".clock");
       n.named_tuples(
         "reg-names", "reg",
-        "config", tuple_t<node, target_long>(), [&](node base, target_long offset) {
+        "config", tuple_t<node, target_size>(), [&](node base, target_size offset) {
           emit_struct_field_node("config_base", base, "");
-          emit_struct_field_tl("config_offset", offset);
+          emit_struct_field_ts("config_offset", offset);
         });
       emit_struct_end();
     }, std::regex("sifive,gpio0"), [&](node n) {
@@ -190,9 +198,9 @@ static void write_config_file(const fdt &dtb, fstream &os)
       emit_struct_field("vtable", "&__mee_driver_vtable_sifive_gpio0");
       n.named_tuples(
         "reg-names", "reg",
-        "control", tuple_t<target_long, target_long>(), [&](target_long base, target_long size) {
-          emit_struct_field_tl("base", base);
-          emit_struct_field_tl("size", size);
+        "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
+          emit_struct_field_ta("base", base);
+          emit_struct_field_ts("size", size);
         });
       emit_struct_end();
     }, std::regex("sifive,uart0"), [&](node n) {
@@ -201,21 +209,21 @@ static void write_config_file(const fdt &dtb, fstream &os)
       emit_struct_field("uart.vtable", "&__mee_driver_vtable_sifive_uart0.uart");
       n.named_tuples(
         "reg-names", "reg",
-        "control", tuple_t<target_long, target_long>(), [&](target_long base, target_long size) {
-          emit_struct_field_tl("control_base", base);
-          emit_struct_field_tl("control_size", size);
+        "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
+          emit_struct_field_ta("control_base", base);
+          emit_struct_field_ts("control_size", size);
         });
       n.maybe_tuple(
         "clocks", tuple_t<node>(),
         [&](){ emit_struct_field_null("clock"); },
         [&](node n) { emit_struct_field_node("clock", n, ".clock"); });
       n.maybe_tuple(
-        "pinmux", tuple_t<node, target_long, target_long>(),
+        "pinmux", tuple_t<node, uint32_t, uint32_t>(),
         [&](){ emit_struct_field_null("pinmux"); },
-        [&](node n, target_long dest, target_long source) {
+        [&](node n, uint32_t dest, uint32_t source) {
             emit_struct_field_node("pinmux", n, "");
-            emit_struct_field_tl("pinmux_output_selector", dest);
-            emit_struct_field_tl("pinmux_source_selector", source);
+            emit_struct_field_u32("pinmux_output_selector", dest);
+            emit_struct_field_u32("pinmux_source_selector", source);
         });
       emit_struct_end();
     }, std::regex("sifive,test0"), [&](node n) {
@@ -224,9 +232,9 @@ static void write_config_file(const fdt &dtb, fstream &os)
       emit_struct_field("shutdown.vtable", "&__mee_driver_vtable_sifive_test0.shutdown");
       n.named_tuples(
         "reg-names", "reg",
-        "control", tuple_t<target_long, target_long>(), [&](target_long base, target_long size) {
-          emit_struct_field_tl("base", base);
-          emit_struct_field_tl("size", size);
+        "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
+          emit_struct_field_ta("base", base);
+          emit_struct_field_ts("size", size);
         });
       emit_struct_end();
       emit_def_handle("__MEE_DT_SHUTDOWN_HANDLE", n, ".shutdown");

--- a/tests/e51-arty-ldscript.bash
+++ b/tests/e51-arty-ldscript.bash
@@ -5,5 +5,15 @@ trap "rm -rf $tempdir" EXIT
 
 cd "$tempdir"
 
+cat $SOURCE_DIR/tests/e51-arty.dts
+
 dtc $SOURCE_DIR/tests/e51-arty.dts -o e51-arty.dtb -O dtb
 $WORK_DIR/freedom-ldscript-generator -d e51-arty.dtb -l e51-arty.lds
+
+cat e51-arty.lds
+
+if [[ "$(grep "ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000" e51-arty.lds | wc -l)" == 0 ]]
+then
+    echo "Incorrect RAM address region" >&2
+    exit 1
+fi

--- a/tests/e51-arty.dts
+++ b/tests/e51-arty.dts
@@ -1,12 +1,12 @@
 /dts-v1/;
 
 / {
-	#address-cells = <1>;
-	#size-cells = <1>;
+	#address-cells = <2>;
+	#size-cells = <2>;
 	compatible = "SiFive,FE510G-dev", "fe510-dev", "sifive-dev";
 	model = "SiFive,FE510G";
 	L17: cpus {
-		#address-cells = <1>;
+		#address-cells = <2>;
 		#size-cells = <0>;
 		L6: cpu@0 {
 			clock-frequency = <0>;
@@ -16,7 +16,7 @@
 			i-cache-sets = <128>;
 			i-cache-size = <16384>;
 			next-level-cache = <&L12>;
-			reg = <0>;
+			reg = <0 0>;
 			riscv,isa = "rv64imac";
 			sifive,dtim = <&L5>;
 			sifive,itim = <&L4>;
@@ -30,8 +30,8 @@
 		};
 	};
 	L16: soc {
-		#address-cells = <1>;
-		#size-cells = <1>;
+		#address-cells = <2>;
+		#size-cells = <2>;
 		compatible = "SiFive,FE510G-soc", "fe510-soc", "sifive-soc", "simple-bus";
 		ranges;
                 refclk: refclk {
@@ -43,23 +43,23 @@
 		L1: clint@2000000 {
 			compatible = "riscv,clint0";
 			interrupts-extended = <&L3 3 &L3 7>;
-			reg = <0x2000000 0x10000>;
+			reg = <0x0 0x2000000 0x0 0x10000>;
 			reg-names = "control";
 		};
 		L2: debug-controller@0 {
 			compatible = "sifive,debug-013", "riscv,debug-013";
 			interrupts-extended = <&L3 65535>;
-			reg = <0x0 0x1000>;
+			reg = <0x0 0x0 0x0 0x1000>;
 			reg-names = "control";
 		};
 		L5: dtim@80000000 {
 			compatible = "sifive,dtim0";
-			reg = <0x80000000 0x10000>;
+			reg = <0x0 0x80000000 0x0 0x10000>;
 			reg-names = "mem";
 		};
 		L8: error-device@3000 {
 			compatible = "sifive,error0";
-			reg = <0x3000 0x1000>;
+			reg = <0x0 0x3000 0x0 0x1000>;
 			reg-names = "mem";
 		};
 		L9: global-external-interrupts {
@@ -70,7 +70,7 @@
 			compatible = "sifive,gpio0";
 			interrupt-parent = <&L0>;
 			interrupts = <7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22>;
-			reg = <0x20002000 0x1000>;
+			reg = <0x0 0x20002000 0x0 0x1000>;
 			reg-names = "control";
 		};
 		L0: interrupt-controller@c000000 {
@@ -78,14 +78,14 @@
 			compatible = "riscv,plic0";
 			interrupt-controller;
 			interrupts-extended = <&L3 11>;
-			reg = <0xc000000 0x4000000>;
+			reg = <0x0 0xc000000 0x0 0x4000000>;
 			reg-names = "control";
 			riscv,max-priority = <7>;
 			riscv,ndev = <26>;
 		};
 		L4: itim@8000000 {
 			compatible = "sifive,itim0";
-			reg = <0x8000000 0x4000>;
+			reg = <0x0 0x8000000 0x0 0x4000>;
 			reg-names = "mem";
 		};
 		L10: local-external-interrupts-0 {
@@ -96,14 +96,14 @@
 			compatible = "sifive,pwm0";
 			interrupt-parent = <&L0>;
 			interrupts = <23 24 25 26>;
-			reg = <0x20005000 0x1000>;
+			reg = <0x0 0x20005000 0x0 0x1000>;
 			reg-names = "control";
 		};
 		L11: serial@20000000 {
 			compatible = "sifive,uart0";
 			interrupt-parent = <&L0>;
 			interrupts = <5>;
-			reg = <0x20000000 0x1000>;
+			reg = <0x0 0x20000000 0x0 0x1000>;
 			reg-names = "control";
 			clocks = <&refclk>;
 		};
@@ -111,12 +111,12 @@
 			compatible = "sifive,spi0";
 			interrupt-parent = <&L0>;
 			interrupts = <6>;
-			reg = <0x20004000 0x1000 0x40000000 0x20000000>;
+			reg = <0x0 0x20004000 0x0 0x1000 0x0 0x40000000 0x0 0x20000000>;
 			reg-names = "control", "mem";
 		};
 		L7: teststatus@4000 {
 			compatible = "sifive,test0";
-			reg = <0x4000 0x1000>;
+			reg = <0x0 0x4000 0x0 0x1000>;
 			reg-names = "control";
 		};
 	};


### PR DESCRIPTION
This respects #address-cells and #size-cells to determine the number of
cells in a target address or size field.  It also splits 'target_long'
into 'target_addr' and 'target_size' to respect the difference.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>