### PR TITLE
A pair of testram-based fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,11 @@ TESTS      += tests/multi-e31-arty-openocd.bash
 TESTS      += tests/multi-e31-arty-makeattributes.bash
 TESTS      += tests/multi-e31-arty-mee_header.bash
 EXTRA_DIST += tests/multi-e31-arty.dts
+TESTS      += tests/e31-bigmem-ldscript.bash
+TESTS      += tests/e31-bigmem-openocd.bash
+TESTS      += tests/e31-bigmem-makeattributes.bash
+TESTS      += tests/e31-bigmem-mee_header.bash
+EXTRA_DIST += tests/e31-bigmem.dts
 
 EXTRA_DIST += $(TESTS)
 

--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -242,7 +242,10 @@ static void write_linker_memory (fstream &os, bool scratchpad)
 	continue;
       }
       os << " : ORIGIN = 0x" << std::hex << (entry.mem_start + flash_offset);
-      os << ", LENGTH = 0x" << entry.mem_length;
+      /* FIXME: Here we restrict the length of any segment to 2GiB.  While this
+       * isn't technically correct, it does at least prevent us from ending up
+       * with segments that are too large for */
+      os << ", LENGTH = 0x" << ((entry.mem_length > 0x80000000UL) ? 0x80000000UL : entry.mem_length);
       os << std::dec << std::endl;
     }
     os << "}" << std::endl << std::endl;

--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -175,7 +175,7 @@ static void dts_memory (void)
                 "mem", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
                     auto basestr = std::to_string(base);
                     if (testram_count == 0)
-                        dts_memory_list.push_back(memory("mem", "spi", basestr, base, size));
+                        dts_memory_list.push_back(memory("mem", "testram", basestr, base, size));
                     testram_count++;
                 });
         },
@@ -187,14 +187,17 @@ static void dts_memory (void)
                 "mem", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
                     auto basestr = std::to_string(base);
                     if (spi_count == 0)
-                        dts_memory_list.push_back(memory("mem", "testram", basestr, base, size));
+                        dts_memory_list.push_back(memory("mem", "spi", basestr, base, size));
                     spi_count++;
                 });
         });
 
-    alias_memory("dtim", "ram");
-    alias_memory("spi", "flash");
-    alias_memory("testram", "flash");
+    if (testram_count > 0)
+        alias_memory("testram", "ram");
+    else {
+        alias_memory("dtim", "ram");
+        alias_memory("spi", "flash");
+    }
 }
 
 static void show_dts_memory (string mtype)
@@ -615,7 +618,7 @@ int main (int argc, char* argv[])
   get_dts_attribute("/cpus/cpu@0", "riscv,isa");
   dts_memory();
 
-  if (has_memory("spi") == 0 && has_memory("testram"))
+  if (has_memory("spi") == 0)
     scratchpad = true;
 
   if (!linker_file.empty()) {

--- a/tests/e31-bigmem-ldscript.bash
+++ b/tests/e31-bigmem-ldscript.bash
@@ -1,0 +1,28 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-bigmem.dts -o e31-bigmem.dtb -O dtb
+$WORK_DIR/freedom-ldscript-generator -d e31-bigmem.dtb -l e31-bigmem.lds
+
+cat e31-bigmem.lds
+if [[ "$(grep ">ram" e31-bigmem.lds | wc -l)" == 0 ]]
+then
+    echo "The E31 eval config must load code into the ahb-periph-port" >&2
+    exit 1
+fi
+
+if [[ "$(grep "ram (wxa!ri) : ORIGIN = 0x20000000, LENGTH = 0x80000000" e31-bigmem.lds | wc -l)" == 0 ]]
+then
+    echo "The E31 eval config must load code into the test RAM next to the AHB periph port" >&2
+    exit 1
+fi
+
+if [[ "$(grep ">flash" e31-bigmem.lds | wc -l)" != 0 ]]
+then
+    echo "The E31 eval config can't reference a SPI flash as there isn't one" >&2
+    exit 1
+fi

--- a/tests/e31-bigmem-makeattributes.bash
+++ b/tests/e31-bigmem-makeattributes.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-bigmem.dts -o e31-bigmem.dtb -O dtb
+$WORK_DIR/freedom-makeattributes-generator -d e31-bigmem.dtb -o e31-bigmem-build.env

--- a/tests/e31-bigmem-mee_header.bash
+++ b/tests/e31-bigmem-mee_header.bash
@@ -1,0 +1,16 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-bigmem.dts -o e31-bigmem.dtb -O dtb
+$WORK_DIR/freedom-mee_header-generator -d e31-bigmem.dtb -o e31-bigmem.h
+
+cat e31-bigmem.h
+if [[ "$(grep "struct __mee_driver_sifive_test0" e31-bigmem.h | wc -l)" == 0 ]]
+then
+    echo "The E31 evaluation config has a test finisher that must be used, as otherwise the RTL test harness will take forever to run." >&2
+    exit 1
+fi

--- a/tests/e31-bigmem-openocd.bash
+++ b/tests/e31-bigmem-openocd.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-bigmem.dts -o e31-bigmem.dtb -O dtb
+$WORK_DIR/freedom-openocdcfg-generator -b arty -d e31-bigmem.dtb -o e31-bigmem-openocd.cfg

--- a/tests/e31-bigmem.dts
+++ b/tests/e31-bigmem.dts
@@ -1,0 +1,105 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "SiFive,FE310G-dev", "fe310-dev", "sifive-dev";
+	model = "SiFive,FE310G";
+	L15: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		L6: cpu@0 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <128>;
+			i-cache-size = <16384>;
+			reg = <0>;
+			riscv,isa = "rv32imac";
+			sifive,dtim = <&L5>;
+			sifive,itim = <&L4>;
+			status = "okay";
+			timebase-frequency = <1000000>;
+			L3: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L14: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "SiFive,FE310G-soc", "fe310-soc", "sifive-soc", "simple-bus";
+		ranges;
+		L12: ahb-periph-port@20000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "simple-bus";
+			ranges = <0x20000000 0x20000000 0x2000>;
+		};
+		L11: ahb-sys-port@40000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "simple-bus";
+			ranges = <0x40000000 0x40000000 0x2000>;
+		};
+		L1: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L3 3 &L3 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L2: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L3 65535>;
+			reg = <0x0 0x1000>;
+			reg-names = "control";
+		};
+		L5: dtim@80000000 {
+			compatible = "sifive,dtim0";
+			reg = <0x80000000 0x4000>;
+			reg-names = "mem";
+		};
+		L8: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+			reg-names = "mem";
+		};
+		L9: global-external-interrupts {
+			interrupt-parent = <&L0>;
+			interrupts = <1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127>;
+		};
+		L0: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L3 11>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <127>;
+		};
+		L4: itim@8000000 {
+			compatible = "sifive,itim0";
+			reg = <0x8000000 0x4000>;
+			reg-names = "mem";
+		};
+		L10: local-external-interrupts-0 {
+			interrupt-parent = <&L3>;
+			interrupts = <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31>;
+		};
+		L7: teststatus@4000 {
+			compatible = "sifive,test0";
+			reg = <0x4000 0x1000>;
+			reg-names = "control";
+		};
+		test_memory: testram@20000000 {
+			compatible = "sifive,testram0";
+			reg = <0x20000000 0xFFFFFFFF>;
+			reg-names = "mem";
+			word-size-bytes = <4>;
+		};
+	};
+};

--- a/tests/e31-eval-ldscript.bash
+++ b/tests/e31-eval-ldscript.bash
@@ -9,14 +9,21 @@ dtc $SOURCE_DIR/tests/e31-eval.dts -o e31-eval.dtb -O dtb
 $WORK_DIR/freedom-ldscript-generator -d e31-eval.dtb -l e31-eval.lds
 
 cat e31-eval.lds
-if [[ "$(grep ">flash" e31-eval.lds | wc -l)" == 0 ]]
+if [[ "$(grep ">ram" e31-eval.lds | wc -l)" == 0 ]]
 then
     echo "The E31 eval config must load code into the ahb-periph-port" >&2
     exit 1
 fi
 
-if [[ "$(grep "flash (rxai!w) : ORIGIN = 0x20000000, LENGTH = 0x2000" e31-eval.lds | wc -l)" == 0 ]]
+if [[ "$(grep "ram (wxa!ri) : ORIGIN = 0x20000000, LENGTH = 0x2000" e31-eval.lds | wc -l)" == 0 ]]
 then
     echo "The E31 eval config must load code into the test RAM next to the AHB periph port" >&2
     exit 1
 fi
+
+if [[ "$(grep ">flash" e31-eval.lds | wc -l)" != 0 ]]
+then
+    echo "The E31 eval config can't reference a SPI flash as there isn't one" >&2
+    exit 1
+fi
+

--- a/tests/multi-e31-arty-ldscript.bash
+++ b/tests/multi-e31-arty-ldscript.bash
@@ -5,6 +5,8 @@ trap "rm -rf $tempdir" EXIT
 
 cd "$tempdir"
 
+cat $SOURCE_DIR/tests/multi-e31-arty.dts
+
 dtc $SOURCE_DIR/tests/multi-e31-arty.dts -o multi-e31-arty.dtb -O dtb
 $WORK_DIR/freedom-ldscript-generator -d multi-e31-arty.dtb -l multi-e31-arty.lds
 


### PR DESCRIPTION
This pull request contains three fixes to testram-based systems:
* When a system has a testram everything should be placed in there.
* The testram should be called "ram", not "flash".
* The stack can't be more than 2GiB away from the startup code as otherwise the address can't be loaded.  There's a hack for this one :).