### PR TITLE
Support "sifive,periph-port" and "sifive,sys-port" entries

### DIFF
--- a/fdt.c++
+++ b/fdt.c++
@@ -195,7 +195,10 @@ int fdt::match(const std::regex& r, std::function<void(const node&)> f) const
         if (compat_bytes != nullptr) {
             for (int i = 0; i < compat_len; i += strlen(compat_bytes)) {
                 auto compat = std::string(&compat_bytes[i]);
-                if (compat.length() == 0 || !std::regex_match(compat, r))
+                i++;
+                if (i >= compat_len)
+                    break;
+                if (!std::regex_match(compat, r))
                     continue;
                 f(node(_dts_blob, offset, depth));
                 matches++;

--- a/tests/e31-eval.dts
+++ b/tests/e31-eval.dts
@@ -36,13 +36,13 @@
 		L12: ahb-periph-port@20000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
-			compatible = "simple-bus";
+			compatible = "sifive,ahb-periph-port", "sifive,periph-port", "simple-bus";
 			ranges = <0x20000000 0x20000000 0x2000>;
 		};
 		L11: ahb-sys-port@40000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
-			compatible = "simple-bus";
+			compatible = "sifive,ahb-sys-port", "sifive,sys-port", "simple-bus";
 			ranges = <0x40000000 0x40000000 0x2000>;
 		};
 		L1: clint@2000000 {
@@ -94,12 +94,6 @@
 			compatible = "sifive,test0";
 			reg = <0x4000 0x1000>;
 			reg-names = "control";
-		};
-		test_memory: testram@20000000 {
-			compatible = "sifive,testram0";
-			reg = <0x20000000 0x2000>;
-			reg-names = "mem";
-			word-size-bytes = <4>;
 		};
 	};
 };

--- a/tests/hifive1.dts
+++ b/tests/hifive1.dts
@@ -72,6 +72,7 @@
                         clock-names = "pllref", "pllsel0";
                         reg = <&prci 0x8 &prci 0xc>;
                         reg-names = "config", "divider";
+			clock-frequency = <16000000>;
                 };
 
                 lfroscin: clock@5 {


### PR DESCRIPTION
These entries can be generated along with the hardware and deprecate the "sifive,testram0" entries that we used to have to manually add.