### PR TITLE
Add support for rv32imafdc cores

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,9 +74,16 @@ TESTS      += tests/e31-bigmem-openocd.bash
 TESTS      += tests/e31-bigmem-makeattributes.bash
 TESTS      += tests/e31-bigmem-mee_header.bash
 EXTRA_DIST += tests/e31-bigmem.dts
+TESTS      += tests/e34-eval-ldscript.bash
+TESTS      += tests/e34-eval-openocd.bash
+TESTS      += tests/e34-eval-makeattributes.bash
+TESTS      += tests/e34-eval-mee_header.bash
+TESTS      += tests/e34-eval-mee_specs.bash
+EXTRA_DIST += tests/e34-eval.dts
 
 EXTRA_DIST += $(TESTS)
 
 EXTRA_DIST += README.md
 EXTRA_DIST += fdt.h++
 EXTRA_DIST += libfdt.h++
+EXTRA_DIST += multilib.h++

--- a/freedom-makeattributes-generator.c++
+++ b/freedom-makeattributes-generator.c++
@@ -18,6 +18,7 @@ extern "C"{
 #ifdef __cplusplus
 }
 #endif
+#include "multilib.h++"
 
 using std::cout;
 using std::endl;
@@ -229,10 +230,9 @@ static void write_config_file (fstream &os, std::string board)
 
     os << "#" << __FUNCTION__ << std::endl << std::endl;
 
-    isa = get_dts_attribute("/cpus/cpu@0", "riscv,isa");
+    isa = arch2arch(get_dts_attribute("/cpus/cpu@0", "riscv,isa"));
     os << "FRAMEWORK_BOARD_DTS_MARCH=" << isa << std::endl;
-    os << "FRAMEWORK_BOARD_DTS_MABI="
-       << ((isa.compare("rv64imac") == 0) ? "lp64" : "ilp32") << std::endl;
+    os << "FRAMEWORK_BOARD_DTS_MABI=" << arch2abi(isa) << std::endl;
 
     serial = get_dts_attribute("/soc/serial@20000000", "compatible");
     std::size_t found = serial.find("uart0");

--- a/freedom-mee_specs-generator.c++
+++ b/freedom-mee_specs-generator.c++
@@ -18,6 +18,7 @@ extern "C"{
 #ifdef __cplusplus
 }
 #endif
+#include "multilib.h++"
 
 using std::cout;
 using std::endl;
@@ -220,9 +221,9 @@ static void show_dts_attributes (void)
 
 static void write_specs_file (fstream &os, std::string machine, std::string prefix, std::string tuple, std::string gcc_version)
 {
-    string isa = get_dts_attribute("/cpus/cpu@0", "riscv,isa");
-    string abi = (isa.compare("rv64imac") == 0) ? "lp64" : "ilp32";
-    string emul = (abi.compare("lp64") == 0) ? "elf64lriscv" : "elf32lriscv";
+    string isa = arch2arch(get_dts_attribute("/cpus/cpu@0", "riscv,isa"));
+    string abi = arch2abi(isa);
+    string emul = arch2elf(isa);
 
     os << "%rename asm  mee_machine__asm\n";
     os << "*asm:\n";

--- a/multilib.h++
+++ b/multilib.h++
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2018 SiFive, Inc */
+
+#ifndef FDT__MULTILIB_HXX
+#define FDT__MULTILIB_HXX
+
+std::string arch2arch(std::string arch)
+{
+    if (arch == "rv32i")      return "rv32i";
+    if (arch == "rv32im")     return "rv32im";
+    if (arch == "rv32iac")    return "rv32iac";
+    if (arch == "rv32imac")   return "rv32imac";
+    if (arch == "rv32imafc")  return "rv32imafc";
+    if (arch == "rv64imac")   return "rv64imac";
+    if (arch == "rv64imafdc") return "rv64imafdc";
+
+    if (arch == "rv32imafdc") return "rv32imafdc";
+
+    std::cerr << "arch2arch(): unknown arch " << arch << std::endl;
+    abort();
+    return "";
+}
+
+std::string arch2abi(std::string arch)
+{
+    if (arch == "rv32i")      return "ilp32";
+    if (arch == "rv32im")     return "ilp32";
+    if (arch == "rv32iac")    return "ilp32";
+    if (arch == "rv32imac")   return "ilp32";
+    if (arch == "rv32imafc")  return "ilp32f";
+    if (arch == "rv64imac")   return "lp64";
+    if (arch == "rv64imafdc") return "lp64d";
+
+    if (arch == "rv32imafdc") return "ilp32f";
+
+    std::cerr << "arch2abi(): unknown arch " << arch << std::endl;
+    abort();
+    return "";
+}
+
+std::string arch2elf(std::string arch)
+{
+    if (arch.substr(0, 4) == "rv32") return "elf32lriscv";
+    if (arch.substr(0, 4) == "rv64") return "elf64lriscv";
+
+    std::cerr << "arch2elf(): unknown arch " << arch << std::endl;
+    std::cerr << "    arch.substr(0, 4): " << arch.substr(0, 4) << std::endl;
+    abort();
+    return "";
+}
+
+#endif

--- a/tests/e34-eval-ldscript.bash
+++ b/tests/e34-eval-ldscript.bash
@@ -1,0 +1,29 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e34-eval.dts -o e34-eval.dtb -O dtb
+$WORK_DIR/freedom-ldscript-generator -d e34-eval.dtb -l e34-eval.lds
+
+cat e34-eval.lds
+if [[ "$(grep ">ram" e34-eval.lds | wc -l)" == 0 ]]
+then
+    echo "The E34 eval config must load code into the ahb-periph-port" >&2
+    exit 1
+fi
+
+if [[ "$(grep "ram (wxa!ri) : ORIGIN = 0x20000000, LENGTH = 0x2000" e34-eval.lds | wc -l)" == 0 ]]
+then
+    echo "The E34 eval config must load code into the test RAM next to the AHB periph port" >&2
+    exit 1
+fi
+
+if [[ "$(grep ">flash" e34-eval.lds | wc -l)" != 0 ]]
+then
+    echo "The E34 eval config can't reference a SPI flash as there isn't one" >&2
+    exit 1
+fi
+

--- a/tests/e34-eval-makeattributes.bash
+++ b/tests/e34-eval-makeattributes.bash
@@ -1,0 +1,21 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e34-eval.dts -o e34-eval.dtb -O dtb
+$WORK_DIR/freedom-makeattributes-generator -d e34-eval.dtb -o e34-eval-build.env
+
+if [[ "$(cat e34-eval-build.env | grep FRAMEWORK_BOARD_DTS_MARCH=rv32imafdc | wc -l)" == 0 ]]
+then
+    echo "wrong march"
+    exit 1
+fi
+
+if [[ "$(cat e34-eval-build.env | grep FRAMEWORK_BOARD_DTS_MABI=ilp32f | wc -l)" == 0 ]]
+then
+    echo "wrong mabi"
+    exit 1
+fi

--- a/tests/e34-eval-mee_header.bash
+++ b/tests/e34-eval-mee_header.bash
@@ -1,0 +1,16 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e34-eval.dts -o e34-eval.dtb -O dtb
+$WORK_DIR/freedom-mee_header-generator -d e34-eval.dtb -o e34-eval.h
+
+cat e34-eval.h
+if [[ "$(grep "struct __mee_driver_sifive_test0" e34-eval.h | wc -l)" == 0 ]]
+then
+    echo "The E31 evaluation config has a test finisher that must be used, as otherwise the RTL test harness will take forever to run." >&2
+    exit 1
+fi

--- a/tests/e34-eval-mee_specs.bash
+++ b/tests/e34-eval-mee_specs.bash
@@ -1,0 +1,23 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e34-eval.dts -o e34-eval.dtb -O dtb
+$WORK_DIR/freedom-mee_specs-generator -d e34-eval.dtb -s e34-eval-build.env --prefix $(pwd)/p
+
+cat e34-eval-build.env
+
+if [[ "$(cat e34-eval-build.env | grep march=rv32imafdc | wc -l)" == 0 ]]
+then
+    echo "wrong march"
+    exit 1
+fi
+
+if [[ "$(cat e34-eval-build.env | grep mabi=ilp32f | wc -l)" == 0 ]]
+then
+    echo "wrong mabi"
+    exit 1
+fi

--- a/tests/e34-eval-openocd.bash
+++ b/tests/e34-eval-openocd.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e34-eval.dts -o e34-eval.dtb -O dtb
+$WORK_DIR/freedom-openocdcfg-generator -b arty -d e34-eval.dtb -o e34-eval-openocd.cfg

--- a/tests/e34-eval.dts
+++ b/tests/e34-eval.dts
@@ -1,0 +1,99 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "SiFive,FE340G-dev", "fe340-dev", "sifive-dev";
+	model = "SiFive,FE340G";
+	L15: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		L6: cpu@0 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <128>;
+			i-cache-size = <16384>;
+			reg = <0>;
+			riscv,isa = "rv32imafdc";
+			sifive,dtim = <&L5>;
+			sifive,itim = <&L4>;
+			status = "okay";
+			timebase-frequency = <1000000>;
+			L3: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L14: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "SiFive,FE340G-soc", "fe340-soc", "sifive-soc", "simple-bus";
+		ranges;
+		L12: ahb-periph-port@20000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "sifive,ahb-periph-port", "sifive,periph-port", "simple-bus";
+			ranges = <0x20000000 0x20000000 0x2000>;
+		};
+		L11: ahb-sys-port@40000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "sifive,ahb-sys-port", "sifive,sys-port", "simple-bus";
+			ranges = <0x40000000 0x40000000 0x2000>;
+		};
+		L1: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L3 3 &L3 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L2: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L3 65535>;
+			reg = <0x0 0x1000>;
+			reg-names = "control";
+		};
+		L5: dtim@80000000 {
+			compatible = "sifive,dtim0";
+			reg = <0x80000000 0x4000>;
+			reg-names = "mem";
+		};
+		L8: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+			reg-names = "mem";
+		};
+		L9: global-external-interrupts {
+			interrupt-parent = <&L0>;
+			interrupts = <1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127>;
+		};
+		L0: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L3 11>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <127>;
+		};
+		L4: itim@8000000 {
+			compatible = "sifive,itim0";
+			reg = <0x8000000 0x4000>;
+			reg-names = "mem";
+		};
+		L10: local-external-interrupts-0 {
+			interrupt-parent = <&L3>;
+			interrupts = <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31>;
+		};
+		L7: teststatus@4000 {
+			compatible = "sifive,test0";
+			reg = <0x4000 0x1000>;
+			reg-names = "control";
+		};
+	};
+};


### PR DESCRIPTION
The default set of multilibs on RISC-V GCC implementations doesn't
include a sane setting for rv32imafdc/ilp32.  While this is arguably a
bug (it could be implemented with the rv32imac/ilp32 library), it's also
probably best to be mapping these to rv32imafdc/ilp32f as users probably
want to take advantage of their F registers when calling functions.

In the long run we should fix the multilib generator to provide a
complete set of multilibs, but for now we'll have to live with these
lookup tables.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>