### PR TITLE
If there is no explicit external bus then match simple-bus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,11 @@ TESTS      += tests/e34-eval-makeattributes.bash
 TESTS      += tests/e34-eval-mee_header.bash
 TESTS      += tests/e34-eval-mee_specs.bash
 EXTRA_DIST += tests/e34-eval.dts
+TESTS      += tests/e31-eval-simple_bus-ldscript.bash
+TESTS      += tests/e31-eval-simple_bus-openocd.bash
+TESTS      += tests/e31-eval-simple_bus-makeattributes.bash
+TESTS      += tests/e31-eval-simple_bus-mee_header.bash
+EXTRA_DIST += tests/e31-eval-simple_bus.dts
 
 EXTRA_DIST += $(TESTS)
 

--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -156,6 +156,7 @@ static void dts_memory (void)
     int spi_count = 0;
     int periph_count = 0;
     int sys_count = 0;
+    int bus_count = 0;
 
     auto dtb = fdt((const uint8_t *)dts_blob);
     dtb.match(
@@ -203,6 +204,18 @@ static void dts_memory (void)
                     sys_count++;
                 });
         },
+        std::regex("simple-bus"), [&](node n) {
+            auto name = n.name();
+            n.maybe_tuple(
+                "ranges", tuple_t<target_addr, target_addr, target_size>(),
+                [&]() {},
+                [&](target_addr src, target_addr dest, target_size len) {
+                    if (bus_count == 0)
+                        dts_memory_list.push_back(memory("mem", "bus_ram", "simple-bus", src, len));
+
+                    bus_count++;
+                });
+        },
         std::regex("sifive,spi0"), [&](node n) {
             auto name = n.name();
             n.named_tuples(
@@ -221,6 +234,8 @@ static void dts_memory (void)
         alias_memory("periph_ram", "ram");
     else if (sys_count > 0)
         alias_memory("sys_ram", "ram");
+    else if (bus_count > 0)
+        alias_memory("bus_ram", "ram");
     else {
         alias_memory("dtim", "ram");
         alias_memory("spi", "flash");

--- a/tests/e31-eval-simple_bus-ldscript.bash
+++ b/tests/e31-eval-simple_bus-ldscript.bash
@@ -1,0 +1,29 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-eval-simple_bus.dts -o e31-eval-simple_bus.dtb -O dtb
+$WORK_DIR/freedom-ldscript-generator -d e31-eval-simple_bus.dtb -l e31-eval-simple_bus.lds
+
+cat e31-eval-simple_bus.lds
+if [[ "$(grep ">ram" e31-eval-simple_bus.lds | wc -l)" == 0 ]]
+then
+    echo "The E31 eval-simple_bus config must load code into the ahb-periph-port" >&2
+    exit 1
+fi
+
+if [[ "$(grep "ram (wxa!ri) : ORIGIN = 0x20000000, LENGTH = 0x2000" e31-eval-simple_bus.lds | wc -l)" == 0 ]]
+then
+    echo "The E31 eval-simple_bus config must load code into the test RAM next to the AHB periph port" >&2
+    exit 1
+fi
+
+if [[ "$(grep ">flash" e31-eval-simple_bus.lds | wc -l)" != 0 ]]
+then
+    echo "The E31 eval-simple_bus config can't reference a SPI flash as there isn't one" >&2
+    exit 1
+fi
+

--- a/tests/e31-eval-simple_bus-makeattributes.bash
+++ b/tests/e31-eval-simple_bus-makeattributes.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-eval-simple_bus.dts -o e31-eval-simple_bus.dtb -O dtb
+$WORK_DIR/freedom-makeattributes-generator -d e31-eval-simple_bus.dtb -o e31-eval-simple_bus-build.env

--- a/tests/e31-eval-simple_bus-mee_header.bash
+++ b/tests/e31-eval-simple_bus-mee_header.bash
@@ -1,0 +1,16 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-eval-simple_bus.dts -o e31-eval-simple_bus.dtb -O dtb
+$WORK_DIR/freedom-mee_header-generator -d e31-eval-simple_bus.dtb -o e31-eval-simple_bus.h
+
+cat e31-eval-simple_bus.h
+if [[ "$(grep "struct __mee_driver_sifive_test0" e31-eval-simple_bus.h | wc -l)" == 0 ]]
+then
+    echo "The E31 eval-simple_busuation config has a test finisher that must be used, as otherwise the RTL test harness will take forever to run." >&2
+    exit 1
+fi

--- a/tests/e31-eval-simple_bus-openocd.bash
+++ b/tests/e31-eval-simple_bus-openocd.bash
@@ -1,0 +1,9 @@
+set -e
+
+tempdir="$(mktemp -d)"
+trap "rm -rf $tempdir" EXIT
+
+cd "$tempdir"
+
+dtc $SOURCE_DIR/tests/e31-eval-simple_bus.dts -o e31-eval-simple_bus.dtb -O dtb
+$WORK_DIR/freedom-openocdcfg-generator -b arty -d e31-eval-simple_bus.dtb -o e31-eval-simple_bus-openocd.cfg

--- a/tests/e31-eval-simple_bus.dts
+++ b/tests/e31-eval-simple_bus.dts
@@ -1,0 +1,99 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "SiFive,FE310G-dev", "fe310-dev", "sifive-dev";
+	model = "SiFive,FE310G";
+	L15: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		L6: cpu@0 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <128>;
+			i-cache-size = <16384>;
+			reg = <0>;
+			riscv,isa = "rv32imac";
+			sifive,dtim = <&L5>;
+			sifive,itim = <&L4>;
+			status = "okay";
+			timebase-frequency = <1000000>;
+			L3: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L14: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "SiFive,FE310G-soc", "fe310-soc", "sifive-soc", "simple-bus";
+		ranges;
+		L12: ahb-periph-port@20000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "simple-bus";
+			ranges = <0x20000000 0x20000000 0x2000>;
+		};
+		L11: ahb-sys-port@40000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "simple-bus";
+			ranges = <0x40000000 0x40000000 0x2000>;
+		};
+		L1: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L3 3 &L3 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L2: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L3 65535>;
+			reg = <0x0 0x1000>;
+			reg-names = "control";
+		};
+		L5: dtim@80000000 {
+			compatible = "sifive,dtim0";
+			reg = <0x80000000 0x4000>;
+			reg-names = "mem";
+		};
+		L8: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+			reg-names = "mem";
+		};
+		L9: global-external-interrupts {
+			interrupt-parent = <&L0>;
+			interrupts = <1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127>;
+		};
+		L0: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L3 11>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <127>;
+		};
+		L4: itim@8000000 {
+			compatible = "sifive,itim0";
+			reg = <0x8000000 0x4000>;
+			reg-names = "mem";
+		};
+		L10: local-external-interrupts-0 {
+			interrupt-parent = <&L3>;
+			interrupts = <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31>;
+		};
+		L7: teststatus@4000 {
+			compatible = "sifive,test0";
+			reg = <0x4000 0x1000>;
+			reg-names = "control";
+		};
+	};
+};


### PR DESCRIPTION
This is a bit of a hack, but we have some device trees floating around
that don't have proper device tree entries for their test memories.
Matching on simple-bus alone isn't enough, as we really need to only
look for empty simple busses, but we should be able to get away with
this for now.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>