### PR TITLE
mee_specs-generator: Add support for the "-nostartfiles", "-nostdlib", and "-T" GCC arguments

### DIFF
--- a/freedom-mee_specs-generator.c++
+++ b/freedom-mee_specs-generator.c++
@@ -246,12 +246,12 @@ static void write_specs_file (fstream &os, std::string machine, std::string pref
     os << "\n";
 
     os << "*startfile:\n";
-    os << ""  << prefix << "/" << tuple << "/lib/" << isa << "/" << abi << "/crt0__mee.o"
-       << " " << prefix << "/lib/gcc/" << tuple << "/" << gcc_version << "/" << isa << "/" << abi << "/crtbegin.o\n";
+    os << "%{!nostartfiles:"  << prefix << "/" << tuple << "/lib/" << isa << "/" << abi << "/crt0__mee.o"
+       << " " << prefix << "/lib/gcc/" << tuple << "/" << gcc_version << "/" << isa << "/" << abi << "/crtbegin.o}\n";
     os << "\n";
 
     os << "*endfile:\n";
-    os << ""  << prefix << "/lib/gcc/" << tuple << "/" << gcc_version << "/" << isa << "/" << abi << "/crtend.o\n";
+    os << "%{!nostartfiles:"  << prefix << "/lib/gcc/" << tuple << "/" << gcc_version << "/" << isa << "/" << abi << "/crtend.o}\n";
     os << "\n";
 
     os << "%rename link   mee_machine__link\n";

--- a/freedom-mee_specs-generator.c++
+++ b/freedom-mee_specs-generator.c++
@@ -263,7 +263,7 @@ static void write_specs_file (fstream &os, std::string machine, std::string pref
        << " -m" << emul
        << " -L" << prefix << "/" << tuple << "/lib/" << isa << "/" << abi << "/"
        << " -L" << prefix << "/lib/gcc/" << tuple << "/" << gcc_version << "/" << isa << "/" << abi << "/"
-       << " -lgcc"
+       << " %{!nostdlib:-lgcc}"
        << " %(mee_machine__link)\n";
     os << "\n";
 }

--- a/freedom-mee_specs-generator.c++
+++ b/freedom-mee_specs-generator.c++
@@ -256,7 +256,7 @@ static void write_specs_file (fstream &os, std::string machine, std::string pref
 
     os << "%rename link   mee_machine__link\n";
     os << "*link:\n";
-    os << "-Triscv__mmachine__" << machine << ".lds"
+    os << "%{!T*:-Triscv__mmachine__" << machine << ".lds}"
        << " --gc-sections"
        << " -march=" << isa
        << " -mabi=" << abi


### PR DESCRIPTION
The spec files we generated didn't respect some of the standard GCC arguments.  The specific one that brought this to my attention was the missing support for `-T`, but I found a few more as I poked around the code.