### PR TITLE
Move ITIM section to end of object file

### DIFF
--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -482,72 +482,6 @@ static void write_linker_sections (fstream &os, bool scratchpad, bool ramrodata,
       os << "\t} >flash AT>flash :flash" << std::endl;
     }
 
-    os << std::endl << std::endl;
-    /* Define litimalign section */
-    os << "\t.litimalign \t\t:" << std::endl;
-    os << "\t{" << std::endl;
-    os << "\t\t. = ALIGN(4);" << std::endl;
-    os << "\t\tPROVIDE( mee_segment_itim_source_start = . );" << std::endl;
-    if (itim) {
-      if (scratchpad) {
-        os << "\t} >ram AT>ram :ram" << std::endl;
-      } else {
-        os << "\t} >flash AT>flash :flash" << std::endl;
-      }
-    } else {
-      if (scratchpad) {
-        os << "\t} >ram AT>ram :ram" << std::endl;
-      } else {
-        os << "\t} >flash AT>flash :flash" << std::endl;
-      }
-    }
-
-    os << std::endl << std::endl;
-    /* Define ditimalign section */
-    os << "\t.ditimalign \t\t:" << std::endl;
-    os << "\t{" << std::endl;
-    os << "\t\t. = ALIGN(4);" << std::endl;
-    os << "\t\tPROVIDE( mee_segment_itim_target_start = . );" << std::endl;
-    if (itim) {
-      if (scratchpad) {
-        os << "\t} >itim AT>ram :itim_init" << std::endl;
-      } else {
-        os << "\t} >itim AT>flash :itim_init" << std::endl;
-      }
-    } else {
-      if (scratchpad) {
-        os << "\t} >ram AT>ram :ram_init" << std::endl;
-      } else {
-        os << "\t} >ram AT>flash :ram_init" << std::endl;
-      }
-    }
-
-    os << std::endl << std::endl;
-    /* Define itim section */
-    os << "\t.itim \t\t:" << std::endl;
-    os << "\t{" << std::endl;
-    if (itim ) {
-      os << "\t\t*(.itim .itim.*)" << std::endl;
-    }
-    if (itim) {
-      if (scratchpad) {
-        os << "\t} >itim AT>ram :itim_init" << std::endl;
-      } else {
-        os << "\t} >itim AT>flash :itim_init" << std::endl;
-      }
-    } else {
-      if (scratchpad) {
-        os << "\t} >ram AT>ram :ram_init" << std::endl;
-      } else {
-        os << "\t} >flash AT>flash :flash" << std::endl;
-      }
-    }
-
-    os << std::endl << std::endl;
-    /* Define end labels */
-    os << "\t. = ALIGN(8);" << std::endl;
-    os << "\tPROVIDE( mee_segment_itim_target_end = . );" << std::endl;
-
 
     os << std::endl << std::endl;
     /* Define lalign section */
@@ -652,6 +586,74 @@ static void write_linker_sections (fstream &os, bool scratchpad, bool ramrodata,
       os << "\t\tPROVIDE(mee_segment_stack_end = .);" << std::endl;
     }
     os << "\t} >ram AT>ram :ram" << std::endl;
+
+
+    os << std::endl << std::endl;
+    /* Define litimalign section */
+    os << "\t.litimalign \t\t:" << std::endl;
+    os << "\t{" << std::endl;
+    os << "\t\t. = ALIGN(4);" << std::endl;
+    os << "\t\tPROVIDE( mee_segment_itim_source_start = . );" << std::endl;
+    if (itim) {
+      if (scratchpad) {
+        os << "\t} >ram AT>ram :ram" << std::endl;
+      } else {
+        os << "\t} >flash AT>flash :flash" << std::endl;
+      }
+    } else {
+      if (scratchpad) {
+        os << "\t} >ram AT>ram :ram" << std::endl;
+      } else {
+        os << "\t} >flash AT>flash :flash" << std::endl;
+      }
+    }
+
+    os << std::endl << std::endl;
+    /* Define ditimalign section */
+    os << "\t.ditimalign \t\t:" << std::endl;
+    os << "\t{" << std::endl;
+    os << "\t\t. = ALIGN(4);" << std::endl;
+    os << "\t\tPROVIDE( mee_segment_itim_target_start = . );" << std::endl;
+    if (itim) {
+      if (scratchpad) {
+        os << "\t} >itim AT>ram :itim_init" << std::endl;
+      } else {
+        os << "\t} >itim AT>flash :itim_init" << std::endl;
+      }
+    } else {
+      if (scratchpad) {
+        os << "\t} >ram AT>ram :ram_init" << std::endl;
+      } else {
+        os << "\t} >ram AT>flash :ram_init" << std::endl;
+      }
+    }
+
+    os << std::endl << std::endl;
+    /* Define itim section */
+    os << "\t.itim \t\t:" << std::endl;
+    os << "\t{" << std::endl;
+    if (itim ) {
+      os << "\t\t*(.itim .itim.*)" << std::endl;
+    }
+    if (itim) {
+      if (scratchpad) {
+        os << "\t} >itim AT>ram :itim_init" << std::endl;
+      } else {
+        os << "\t} >itim AT>flash :itim_init" << std::endl;
+      }
+    } else {
+      if (scratchpad) {
+        os << "\t} >ram AT>ram :ram_init" << std::endl;
+      } else {
+        os << "\t} >flash AT>flash :flash" << std::endl;
+      }
+    }
+
+    os << std::endl << std::endl;
+    /* Define end labels */
+    os << "\t. = ALIGN(4);" << std::endl;
+    os << "\tPROVIDE( mee_segment_itim_target_end = . );" << std::endl;
+
 
     os << std::endl << std::endl;
     os << "}" << std::endl << std::endl;


### PR DESCRIPTION
For scratchpad targets, putting the itim sections in the middle of the
ROM confused the linker for sections placed after the itim. To get
around this, put the itim sections and the end of the object file.