### PR TITLE
Increase the stack size to 2K on scratchpad targets

### DIFF
--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -339,7 +339,7 @@ static void write_linker_phdrs (fstream &os, bool scratchpad)
 
 static void write_linker_sections (fstream &os, bool scratchpad, bool ramrodata, bool itim)
 {
-    std::string stack_cfg = scratchpad ? "0x400" : "0x800";
+    std::string stack_cfg = "0x800";
 
   //os << "#" << __FUNCTION__ << std::endl;
     os << "SECTIONS" << std::endl << "{" << std::endl;


### PR DESCRIPTION
This fixes the regression on `printf("%d\n",4)` on 64-bit targets. Odds
are good we were colliding the heap and stack, especially when they were
both squeezed into the same 1K of RAM.