### PR TITLE
Fix SPI device handle array

### DIFF
--- a/metal_header/sifive_spi0.h
+++ b/metal_header/sifive_spi0.h
@@ -95,6 +95,8 @@ class sifive_spi0 : public Device {
 	    } else {
 	      os << ",\n";
 	    }
+
+	    i++;
 	  });
       } else {
 	emit_struct_pointer_end("NULL");


### PR DESCRIPTION
Increment the counter so that we close the array definition with '};'.