### PR TITLE
Multicore Support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ freedom_metal_header_generator_SOURCES = \
 	metal_header/device.c++ \
 	metal_header/device.h \
 	metal_header/fixed_clock.h \
+	metal_header/fixed_factor_clock.h \
 	metal_header/memory.h \
 	metal_header/riscv_clint0.h \
 	metal_header/riscv_cpu.h \

--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -714,25 +714,11 @@ static void write_linker_sections (fstream &os, int num_harts, bool scratchpad, 
 
     os << std::endl << std::endl;
 
-    /* Define heap section
-     *
-     * For scratchpad mode:
-     *   Customer implementations might not map all of the addressable RAM,
-     *   so we want to put the heap immediately after the rest of memory and
-     *   size it to exactly __heap_size.
-     * For non-scratchpad mode:
-     *   We expect all addresses in RAM to be mapped, so start the heap after
-     *   the rest of the memory contents and extend to the top of RAM.
-     */
     os << "\t.heap :" << std::endl;
     os << "\t{" << std::endl;
     os << "\t\tPROVIDE( metal_segment_heap_target_start = . );" << std::endl;
 
     os << "\t\t. = __heap_size;" << std::endl;
-    if (!scratchpad) {
-      /* If the __heap_size == 0, don't let the heap grow to fill the rest of RAM. */
-      os << "\t\t. = __heap_size == 0 ? 0 : ORIGIN(ram) + LENGTH(ram);" << std::endl;
-    }
 
     os << "\t\tPROVIDE( metal_segment_heap_target_end = . );" << std::endl;;
     os << "\t\tPROVIDE( _heap_end = . );" << std::endl;

--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -377,6 +377,7 @@ static void write_linker_sections (fstream &os, int num_harts, bool scratchpad, 
     /* Define stack size */
     os << "\t__stack_size = DEFINED(__stack_size) ? __stack_size : "
 	      << stack_cfg << ";" << std::endl;
+    os << "\tPROVIDE(__stack_size = __stack_size);" << std::endl;
     /* Define heap size */
     os << "\t__heap_size = DEFINED(__heap_size) ? __heap_size : "
 	      << heap_cfg << ";" << std::endl;

--- a/metal_header/device.c++
+++ b/metal_header/device.c++
@@ -94,7 +94,7 @@ void Device::emit_struct_container_node_and_array(int size, std::string field1,
 						std::string field2, uint32_t elem) {
   static int cna = 0;
   if (cna == 0) {
-      os << "    ." << field1 << " = &" << "__metal_dt_" << c.handle() << subfield1 << ",\n";
+      os << "    ." << field1 << " = &" << "__metal_dt_" << c.parent().handle() + "_" + c.handle() << subfield1 << ",\n";
   }
   os << "    ." << field2 << "[" << cna << "] = " << elem << ",\n";
   cna++;

--- a/metal_header/fixed_factor_clock.h
+++ b/metal_header/fixed_factor_clock.h
@@ -1,0 +1,63 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __METAL_HEADER_FIXED_FACTOR_CLOCK__H
+#define __METAL_HEADER_FIXED_FACTOR_CLOCK__H
+
+#include "metal_header/device.h"
+
+#include <regex>
+
+class fixed_factor_clock : public Device {
+  public:
+    fixed_factor_clock(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "fixed-factor-clock")
+    {}
+
+    void include_headers()
+    {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_include(compat_string);
+	}
+      );
+    }
+
+    void declare_structs()
+    {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_struct_decl("fixed_factor_clock", n);
+	}
+      );
+    }
+
+    void define_structs()
+    {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_struct_begin("fixed_factor_clock", n);
+	  emit_struct_field("vtable", "&__metal_driver_vtable_fixed_factor_clock");
+	  emit_struct_field("clock.vtable", "&__metal_driver_vtable_fixed_factor_clock.clock");
+
+	  n.maybe_tuple_index(
+	    "clocks", tuple_t<node>(),
+	    [&]() {
+	      emit_struct_field_null("parent");
+	    },
+	    [&](int i, node c) {
+	      emit_struct_field_node("parent", c, ".clock");
+	    });
+
+	  emit_struct_field("mult", std::to_string(n.get_field<uint32_t>("clock-mult")));
+	  emit_struct_field("div", std::to_string(n.get_field<uint32_t>("clock-div")));
+
+	  emit_struct_end();
+	});
+    }
+};
+
+#endif

--- a/metal_header/freedom-metal_header-generator.c++
+++ b/metal_header/freedom-metal_header-generator.c++
@@ -8,6 +8,7 @@
 /* Generic Devices */
 #include "metal_header/device.h"
 #include "metal_header/fixed_clock.h"
+#include "metal_header/fixed_factor_clock.h"
 #include "metal_header/memory.h"
 #include "metal_header/stdout_path.h"
 
@@ -89,6 +90,7 @@ static void write_config_file(const fdt &dtb, fstream &os, std::string cfg_file)
 
   /* Generic Devices */
   devices.push_back(new fixed_clock(os, dtb));
+  devices.push_back(new fixed_factor_clock(os, dtb));
   devices.push_back(new memory(os, dtb));
   devices.push_back(new stdout_path(os, dtb));
 

--- a/metal_header/riscv_cpu.h
+++ b/metal_header/riscv_cpu.h
@@ -54,7 +54,15 @@ class riscv_cpu : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_cpu");
 	  emit_struct_field("cpu.vtable", "&__metal_driver_vtable_cpu.cpu_vtable");
 
-	  emit_struct_field_u32("timebase", n.get_field<uint32_t>("timebase-frequency"));
+	  n.maybe_tuple(
+	      "timebase-frequency",
+	      tuple_t<uint32_t>(),
+	      [&]() {
+		emit_struct_field_u32("timebase", n.parent().get_field<uint32_t>("timebase-frequency"));
+	      },
+	      [&](uint32_t timebase) {
+		emit_struct_field_u32("timebase", timebase);
+	      });
 
 	  emit_struct_field("interrupt_controller", "&__metal_dt_interrupt_controller.controller");
 

--- a/metal_header/riscv_cpu.h
+++ b/metal_header/riscv_cpu.h
@@ -64,7 +64,7 @@ class riscv_cpu : public Device {
 		emit_struct_field_u32("timebase", timebase);
 	      });
 
-	  emit_struct_field("interrupt_controller", "&__metal_dt_interrupt_controller.controller");
+	  emit_struct_field("interrupt_controller", "&__metal_dt_" + n.handle() + "_interrupt_controller.controller");
 
 	  emit_struct_end();
 	});

--- a/metal_header/riscv_cpu.h
+++ b/metal_header/riscv_cpu.h
@@ -72,12 +72,6 @@ class riscv_cpu : public Device {
 
     void create_handles()
     {
-      dtb.match(
-	std::regex(compat_string),
-	[&](node n) {
-	  emit_def_handle("__METAL_DT_RISCV_CPU_HANDLE", n, ".cpu");
-	});
-
       emit_def("__METAL_DT_MAX_HARTS", std::to_string(num_cpus));
 
       emit_struct_pointer_begin("cpu", "__metal_cpu_table", "[]");

--- a/metal_header/riscv_cpu_intc.h
+++ b/metal_header/riscv_cpu_intc.h
@@ -43,15 +43,6 @@ class riscv_cpu_intc : public Device {
 	  emit_struct_end();
 	});
     }
-
-    void create_handles()
-    {
-      dtb.match(
-	std::regex(compat_string),
-	[&](node n) {
-	  emit_def_handle("__METAL_DT_RISCV_CPU_INTC_HANDLE", n, ".controller");
-      });
-    }
 };
 
 #endif

--- a/metal_header/riscv_cpu_intc.h
+++ b/metal_header/riscv_cpu_intc.h
@@ -8,20 +8,27 @@
 
 #include <regex>
 
+using std::string;
+
 class riscv_cpu_intc : public Device {
   public:
     riscv_cpu_intc(std::ostream &os, const fdt &dtb)
       : Device(os, dtb, "riscv,cpu-intc")
     {}
 
+    string handle(node n)
+    {
+      return n.parent().handle() + "_" + n.handle();
+    }
+
     void declare_structs()
     {
       dtb.match(
 	std::regex(compat_string),
 	[&](node n) {
-	  emit_struct_decl("riscv_cpu_intc", n);
-	}
-      );
+	  os << "asm (\".weak __metal_dt_" << handle(n) << "\");\n";
+	  os << "struct __metal_driver_riscv_cpu_intc __metal_dt_" << handle(n) << ";\n\n";
+	});
     }
 
     void define_structs()
@@ -29,7 +36,8 @@ class riscv_cpu_intc : public Device {
       dtb.match(
 	std::regex(compat_string),
 	[&](node n) {
-	  emit_struct_begin("riscv_cpu_intc", n);
+	  emit_comment(n);
+	  os << "struct __metal_driver_riscv_cpu_intc __metal_dt_" << handle(n) << " = {\n";
 
 	  emit_struct_field("vtable", "&__metal_driver_vtable_riscv_cpu_intc");
 	  emit_struct_field("controller.vtable", "&__metal_driver_vtable_riscv_cpu_intc.controller_vtable");

--- a/metal_header/riscv_plic0.h
+++ b/metal_header/riscv_plic0.h
@@ -10,9 +10,24 @@
 
 class riscv_plic0 : public Device {
   public:
+    int num_parents;
+
     riscv_plic0(std::ostream &os, const fdt &dtb)
       : Device(os, dtb, "riscv,plic0")
-    {}
+    {
+      num_parents = 0;
+
+      dtb.match(
+        std::regex("riscv,plic0"),
+        [&](node n) {
+	  n.maybe_tuple_size(
+	    "interrupts-extended", tuple_t<node, uint32_t>(),
+	    [&](){},
+	    [&](int s, node c, uint32_t line) {
+	      num_parents += 1;
+	    });
+        });
+    }
 
     void create_machine_macros()
     {
@@ -21,11 +36,16 @@ class riscv_plic0 : public Device {
         [&](node n) {
 	  /* Add 1 to number of interrupts for 0 base software index */
           emit_def("__METAL_PLIC_SUBINTERRUPTS", std::to_string(n.get_field<uint32_t>("riscv,ndev") + 1));
+
+          emit_def("__METAL_PLIC_NUM_PARENTS", std::to_string(num_parents));
         });
 
       /* If no PLIC exists, output 0 as a default value */
       os << "#ifndef __METAL_PLIC_SUBINTERRUPTS\n";
       os << "#define __METAL_PLIC_SUBINTERRUPTS 0\n";
+      os << "#endif\n";
+      os << "#ifndef __METAL_PLIC_NUM_PARENTS\n";
+      os << "#define __METAL_PLIC_NUM_PARENTS 0\n";
       os << "#endif\n";
     }
 
@@ -53,6 +73,8 @@ class riscv_plic0 : public Device {
         os << "#define __METAL_PLIC_SUBINTERRUPTS 0\n";
       }
       emit_def("METAL_MAX_PLIC_INTERRUPTS", std::to_string(max_interrupts));
+
+      emit_def("__METAL_PLIC_NUM_PARENTS", std::to_string(num_parents));
     }
 
     void include_headers()
@@ -86,15 +108,15 @@ class riscv_plic0 : public Device {
 
 	  emit_struct_field("init_done", "0");
 
-	  n.maybe_tuple_size(
+	  n.maybe_tuple_index(
 	    "interrupts-extended", tuple_t<node, uint32_t>(),
 	    [&](){
-		emit_struct_field_null("interrupt_parent");
+		emit_struct_field_null("interrupt_parents[0]");
 		emit_struct_field("interrupt_lines[0]", "0");
 	    },
-	    [&](int s, node c, uint32_t line) {
-		emit_struct_container_node_and_array(s, "interrupt_parent", c, ".controller",
-						     "interrupt_lines", line);
+	    [&](int i, node c, uint32_t line) {
+		os << "    .interrupt_parents[" + std::to_string(i) + "] = &__metal_dt_" + c.parent().handle() + "_" + c.handle() + ".controller,\n";
+		os << "    .interrupt_lines[" + std::to_string(i) + "] = " + std::to_string(line) + ",\n";
 	    });
 
 	  n.named_tuples(

--- a/metal_header/riscv_plic0.h
+++ b/metal_header/riscv_plic0.h
@@ -86,15 +86,15 @@ class riscv_plic0 : public Device {
 
 	  emit_struct_field("init_done", "0");
 
-	  n.maybe_tuple(
+	  n.maybe_tuple_size(
 	    "interrupts-extended", tuple_t<node, uint32_t>(),
 	    [&](){
 		emit_struct_field_null("interrupt_parent");
-		emit_struct_field("interrupt_line", "");
+		emit_struct_field("interrupt_lines[0]", "0");
 	    },
-	    [&](node n, uint32_t line) {
-		emit_struct_field_node("interrupt_parent", n, ".controller");
-		emit_struct_field_u32("interrupt_line", line);
+	    [&](int s, node c, uint32_t line) {
+		emit_struct_container_node_and_array(s, "interrupt_parent", c, ".controller",
+						     "interrupt_lines", line);
 	    });
 
 	  n.named_tuples(

--- a/metal_header/sifive_global_external_interrupts0.h
+++ b/metal_header/sifive_global_external_interrupts0.h
@@ -67,7 +67,13 @@ class sifive_global_external_interrupts0 : public Device {
 	  n.maybe_tuple(
 	    "interrupt-parent", tuple_t<node>(),
 	    [&](){ emit_struct_field_null("interrupt_parent"); },
-	    [&](node n) { emit_struct_field_node("interrupt_parent", n, ".controller"); });
+	    [&](node n) {
+		if(n.handle().compare("interrupt_controller") == 0) {
+		  os << "    .interrupt_parent = &__metal_dt_" + n.parent().handle() + "_" + n.handle() + ".controller,\n";
+		} else {
+		  emit_struct_field_node("interrupt_parent", n, ".controller");
+		}
+	      });
 
 	  emit_struct_field("num_interrupts", "METAL_MAX_GLOBAL_EXT_INTERRUPTS");
 

--- a/metal_header/sifive_local_external_interrupts0.h
+++ b/metal_header/sifive_local_external_interrupts0.h
@@ -67,7 +67,13 @@ class sifive_local_external_interrupts0 : public Device {
 	  n.maybe_tuple(
 	    "interrupt-parent", tuple_t<node>(),
 	    [&](){ emit_struct_field_null("interrupt_parent"); },
-	    [&](node n) { emit_struct_field_node("interrupt_parent", n, ".controller"); });
+	    [&](node n) {
+		if(n.handle().compare("interrupt_controller") == 0) {
+		  os << "    .interrupt_parent = &__metal_dt_" + n.parent().handle() + "_" + n.handle() + ".controller,\n";
+		} else {
+		  emit_struct_field_node("interrupt_parent", n, ".controller");
+		}
+	      });
 
 	  emit_struct_field("num_interrupts", "METAL_MAX_LOCAL_EXT_INTERRUPTS");
 


### PR DESCRIPTION
Depends on #64 

PR contains:
- Rename CPU interrupt controllers to cpu_<number>_interrupt_controller to allow multiple to be instantiated
- Support multiple parent interrupts for PLIC and CLINT
- Add a binding for fixed-factor-clock (for HiFive Unleashed)
- Allocate multiple stacks and provide __stack_size as a symbol for the C environment
- Assorted additional fixups for multiple CPU nodes