### PR TITLE
Add freedom-bare_header-generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@
 *.log
 *.trs
 /freedom-metal_header-generator
+/freedom-bare_header-generator
 *.swo
 freedom-metal_specs-generator

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ bin_PROGRAMS =  freedom-ldscript-generator \
 		freedom-openocdcfg-generator \
 		freedom-makeattributes-generator \
 		freedom-metal_header-generator \
+		freedom-bare_header-generator \
 		freedom-zephyrdtsfixup-generator \
 		freedom-metal_specs-generator
 
@@ -49,6 +50,23 @@ freedom_metal_header_generator_SOURCES = \
 	metal_header/sifive_uart0.h \
 	metal_header/stdout_path.h \
 	metal_header/template_device.h
+
+freedom_bare_header_generator_SOURCES = \
+	fdt.c++ \
+	bare_header/freedom-bare_header-generator.c++ \
+	bare_header/device.c++ \
+	bare_header/device.h \
+	bare_header/fixed_clock.h \
+	bare_header/fixed_factor_clock.h \
+	bare_header/riscv_clint0.h \
+	bare_header/riscv_plic0.h \
+	bare_header/riscv_pmp.h \
+	bare_header/sifive_clic0.h \
+	bare_header/sifive_fe310_g000_prci.h \
+	bare_header/sifive_gpio0.h \
+	bare_header/sifive_spi0.h \
+	bare_header/sifive_test0.h \
+	bare_header/sifive_uart0.h
 
 freedom_zephyrdtsfixup_generator_SOURCES = \
 	freedom-zephyrdtsfixup-generator.c++ \

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ freedom_makeattributes_generator_SOURCES = \
 
 freedom_metal_header_generator_SOURCES = \
 	fdt.c++ \
+	header-labels.h \
 	metal_header/freedom-metal_header-generator.c++ \
 	metal_header/device.c++ \
 	metal_header/device.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -53,6 +53,7 @@ freedom_metal_header_generator_SOURCES = \
 
 freedom_bare_header_generator_SOURCES = \
 	fdt.c++ \
+	header-labels.h \
 	bare_header/freedom-bare_header-generator.c++ \
 	bare_header/device.c++ \
 	bare_header/device.h \

--- a/bare_header/device.c++
+++ b/bare_header/device.c++
@@ -45,7 +45,7 @@ uint64_t Device::base_address(const node &n) {
 }
 
 void Device::emit_base(const node &n) {
-  os << "#define " << def_handle(n) << "_BASE_ADDRESS " << base_address(n) << "UL" << std::endl;
+  os << "#define " << def_handle(n) << "_" METAL_BASE_ADDRESS_LABEL << base_address(n) << "UL" << std::endl;
 }
 
 uint64_t Device::size(const node &n) {
@@ -61,7 +61,7 @@ uint64_t Device::size(const node &n) {
 }
 
 void Device::emit_size(const node &n) {
-  os << "#define " << def_handle(n) << "_SIZE " << size(n) << "UL" << std::endl;
+  os << "#define " << def_handle(n) << "_" << METAL_SIZE_LABEL << size(n) << "UL" << std::endl;
 }
 
 void Device::emit_compat() {

--- a/bare_header/device.c++
+++ b/bare_header/device.c++
@@ -1,0 +1,95 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "bare_header/device.h"
+
+#include <algorithm>
+#include <iostream>
+#include <set>
+#include <string>
+
+Device::Device(std::ostream &os, const fdt &dtb, std::string compat_string)
+  : os(os), dtb(dtb), compat_string(compat_string)
+{}
+
+void Device::emit_comment(const node &n) {
+  os << "/* From " << n.name() << " */\n";
+}
+
+string Device::def_handle(const node &n) {
+  string name = compat_string;
+  string instance = n.instance();
+
+  std::transform(name.begin(), name.end(), name.begin(),
+      [](unsigned char c) -> char { 
+	if(c == ',' || c == '-') {
+	  return '_';
+	}
+	return toupper(c);
+      });
+  std::transform(instance.begin(), instance.end(), instance.begin(), toupper);
+
+  return "METAL_" + name + "_" + instance;
+}
+
+uint64_t Device::base_address(const node &n) {
+  uint64_t b;
+
+  n.named_tuples(
+    "reg-names", "reg",
+    "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
+	b = base;
+    });
+
+  return b;
+}
+
+void Device::emit_base(const node &n) {
+  os << "#define " << def_handle(n) << "_BASE_ADDRESS " << base_address(n) << "UL" << std::endl;
+}
+
+uint64_t Device::size(const node &n) {
+  uint64_t s;
+
+  n.named_tuples(
+    "reg-names", "reg",
+    "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
+	s = size;
+  });
+
+  return s;
+}
+
+void Device::emit_size(const node &n) {
+  os << "#define " << def_handle(n) << "_SIZE " << size(n) << "UL" << std::endl;
+}
+
+void Device::emit_compat() {
+  string compat = compat_string;
+  std::transform(compat.begin(), compat.end(), compat.begin(),
+      [](unsigned char c) -> char { 
+	if(c == ',' || c == '-') {
+	  return '_';
+	}
+	return toupper(c);
+      });
+  os << "#define METAL_" << compat << std::endl;
+}
+
+void Device::emit_offset(string offset_name, uint32_t offset) {
+  string name = compat_string;
+  std::transform(name.begin(), name.end(), name.begin(),
+      [](unsigned char c) -> char { 
+	if(c == ',' || c == '-') {
+	  return '_';
+	}
+	return toupper(c);
+      });
+
+  os << "#define METAL_" << name << "_" << offset_name << " " << offset << "UL" << std::endl;
+}
+
+void Device::emit_property_u32(const node &n, string property_name, uint32_t value) {
+  os << "#define " << def_handle(n) << "_" << property_name << " " << value << "UL" << std::endl;
+}
+

--- a/bare_header/device.h
+++ b/bare_header/device.h
@@ -1,0 +1,47 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_DEVICE__H
+#define __BARE_HEADER_DEVICE__H
+
+#include "fdt.h++"
+#include "libfdt.h++"
+
+#include <ostream>
+#include <string>
+
+using std::string;
+
+class Device {
+  public:
+    std::ostream &os;
+
+    /* The "compatable" string for the device */
+    std::string compat_string;
+
+    /* The devicetree */
+    const fdt &dtb;
+
+    Device(std::ostream &os, const fdt &dtb, std::string compat_string);
+
+    virtual void emit_defines() {}
+
+    virtual void emit_offsets() {}
+
+    void emit_comment(const node &n);
+
+    string def_handle(const node &n);
+    virtual uint64_t base_address(const node &n);
+    void emit_base(const node &n);
+
+    virtual uint64_t size(const node &n);
+    void emit_size(const node &n);
+
+    void emit_compat();
+
+    void emit_offset(string offset_name, uint32_t offset);
+
+    void emit_property_u32(const node &n, string property_name, uint32_t value);
+};
+
+#endif

--- a/bare_header/device.h
+++ b/bare_header/device.h
@@ -7,6 +7,8 @@
 #include "fdt.h++"
 #include "libfdt.h++"
 
+#include "header-labels.h"
+
 #include <ostream>
 #include <string>
 

--- a/bare_header/fixed_clock.h
+++ b/bare_header/fixed_clock.h
@@ -1,0 +1,38 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_FIXED_CLOCK__H
+#define __BARE_HEADER_FIXED_CLOCK__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class fixed_clock : public Device {
+  public:
+    fixed_clock(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "fixed-clock")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_property_u32(n, "CLOCK_FREQUENCY", n.get_field<uint32_t>("clock-frequency"));
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/fixed_clock.h
+++ b/bare_header/fixed_clock.h
@@ -20,7 +20,7 @@ class fixed_clock : public Device {
 	[&](node n) {
 	  emit_comment(n);
 
-	  emit_property_u32(n, "CLOCK_FREQUENCY", n.get_field<uint32_t>("clock-frequency"));
+	  emit_property_u32(n, METAL_CLOCK_FREQUENCY_LABEL, n.get_field<uint32_t>("clock-frequency"));
 
 	  os << std::endl;
 	});

--- a/bare_header/fixed_factor_clock.h
+++ b/bare_header/fixed_factor_clock.h
@@ -20,8 +20,8 @@ class fixed_factor_clock : public Device {
 	[&](node n) {
 	  emit_comment(n);
 
-	  emit_property_u32(n, "CLOCK_DIV", n.get_field<uint32_t>("clock-div"));
-	  emit_property_u32(n, "CLOCK_MULT", n.get_field<uint32_t>("clock-mult"));
+	  emit_property_u32(n, METAL_CLOCK_DIV_LABEL, n.get_field<uint32_t>("clock-div"));
+	  emit_property_u32(n, METAL_CLOCK_MULT_LABEL, n.get_field<uint32_t>("clock-mult"));
 
 	  os << std::endl;
 	});

--- a/bare_header/fixed_factor_clock.h
+++ b/bare_header/fixed_factor_clock.h
@@ -1,0 +1,39 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_FIXED_FACTOR_CLOCK__H
+#define __BARE_HEADER_FIXED_FACTOR_CLOCK__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class fixed_factor_clock : public Device {
+  public:
+    fixed_factor_clock(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "fixed-factor-clock")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_property_u32(n, "CLOCK_DIV", n.get_field<uint32_t>("clock-div"));
+	  emit_property_u32(n, "CLOCK_MULT", n.get_field<uint32_t>("clock-mult"));
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/freedom-bare_header-generator.c++
+++ b/bare_header/freedom-bare_header-generator.c++
@@ -1,0 +1,152 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* DeviceTree Library */
+#include "fdt.h++"
+#include "libfdt.h++"
+
+/* STL */
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <list>
+#include <string>
+
+/* Generic Devices */
+#include "bare_header/device.h"
+#include "bare_header/fixed_clock.h"
+#include "bare_header/fixed_factor_clock.h"
+
+/* RISC-V Devices */
+#include "bare_header/riscv_clint0.h"
+#include "bare_header/riscv_plic0.h"
+#include "bare_header/riscv_pmp.h"
+
+/* SiFive Blocks */
+#include "bare_header/sifive_clic0.h"
+#include "bare_header/sifive_fe310_g000_prci.h"
+#include "bare_header/sifive_gpio0.h"
+#include "bare_header/sifive_spi0.h"
+#include "bare_header/sifive_test0.h"
+#include "bare_header/sifive_uart0.h"
+
+using std::cerr;
+using std::endl;
+using std::fstream;
+using std::string;
+
+static void show_usage(string name)
+{
+  std::cerr << "Usage: " << name << " <option(s)>\n"
+	    << "Options:\n"
+	    << "\t-h,--help\t\t\tShow this help message\n"
+	    << "\t-d,--dtb <eg. xxx.dtb>\t\tSpecify fullpath to the DTB file\n"
+	    << "\t-o,--output <eg. ${machine}.h>\tGenerate machine header file\n"
+	    << endl;
+}
+
+void search_replace_all(std::string& str, const std::string& from, const std::string& to) {
+    if (from.empty() || (from.compare(to) == 0))
+        return;
+    size_t pos = 0;
+    while((pos = str.find(from, pos)) != std::string::npos) {
+        str.replace(pos, from.length(), to);
+        pos += to.length();
+    }
+}
+
+static void write_config_file(const fdt &dtb, fstream &os, std::string cfg_file)
+{
+  std::transform(cfg_file.begin(), cfg_file.end(), cfg_file.begin(),
+                   [](unsigned char c) { return (c == '-') ? '_' : toupper(c); });
+  std::transform(cfg_file.begin(), cfg_file.end(), cfg_file.begin(),
+                   [](unsigned char c) { return (c == '.') ? '_' : c; });
+
+  search_replace_all(cfg_file, "/", "__");
+
+  os << "#ifndef " << cfg_file << std::endl;
+  os << "#define " << cfg_file << std::endl << std::endl;
+
+  std::list<Device *> devices;
+
+  /* Generic Devices */
+  devices.push_back(new fixed_clock(os, dtb));
+  devices.push_back(new fixed_factor_clock(os, dtb));
+
+  /* RISC-V Devices */
+  devices.push_back(new riscv_clint0(os, dtb));
+  devices.push_back(new riscv_plic0(os, dtb));
+  devices.push_back(new riscv_pmp(os, dtb));
+
+  /* SiFive Blocks */
+  devices.push_back(new sifive_clic0(os, dtb));
+  devices.push_back(new sifive_fe310_g000_prci(os, dtb));
+  devices.push_back(new sifive_gpio0(os, dtb));
+  devices.push_back(new sifive_spi0(os, dtb));
+  devices.push_back(new sifive_test0(os, dtb));
+  devices.push_back(new sifive_uart0(os, dtb));
+
+  for(auto it = devices.begin(); it != devices.end(); it++) {
+    (*it)->emit_defines();
+    (*it)->emit_offsets();
+  }
+
+  os << "#endif /* " << cfg_file << "*/" << std::endl;
+}
+
+int main (int argc, char* argv[])
+{
+  string dtb_file;
+  string config_file;
+
+  if ((argc < 2) && (argc > 5)) {
+      show_usage(argv[0]);
+      return 1;
+  } else {
+      for (int i = 1; i < argc; ++i) {
+          string arg = argv[i];
+          if ((arg == "-d") || (arg == "--dtb")) {
+              if (i + 1 < argc) {
+                  dtb_file = argv[++i];
+              } else {
+                  std::cerr << "--dtb option requires file path." << std::endl;
+                  show_usage(argv[0]);
+                  return 1;
+              }
+          } else if ((arg == "-o") || (arg == "--output")) {
+              if (i + 1 < argc) {
+                  config_file = argv[++i];
+              } else {
+                  std::cerr << "--output option requires file path." << std::endl;
+                  show_usage(argv[0]);
+                  return 1;
+              }
+          } else {
+              show_usage(argv[0]);
+              return 1;
+          }
+      }
+  }
+
+  if (dtb_file.empty()) {
+      std::cerr << "--dtb option requires file path." << std::endl;
+      show_usage(argv[0]);
+      return 1;
+  }
+
+  fdt f(dtb_file);
+
+  if (!config_file.empty()) {
+    std::fstream cfg;
+
+    cfg.open(config_file, fstream::in | fstream::out | fstream::trunc);
+    if (cfg.is_open() == false) {
+      std::cerr << "Error: Failed to create " << config_file << std::endl;
+      return 1;
+    }
+
+    write_config_file(f, cfg, config_file);
+  }
+
+  return 0;
+}

--- a/bare_header/riscv_clint0.h
+++ b/bare_header/riscv_clint0.h
@@ -1,0 +1,42 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_RISCV_CLINT0__H
+#define __BARE_HEADER_RISCV_CLINT0__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class riscv_clint0 : public Device {
+  public:
+    riscv_clint0(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "riscv,clint0")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+	emit_offset("MSIP_BASE", 0x0);
+	emit_offset("MTIMECMP_BASE", 0x4000);
+	emit_offset("MTIME", 0xBFF8);
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/riscv_clint0.h
+++ b/bare_header/riscv_clint0.h
@@ -30,9 +30,9 @@ class riscv_clint0 : public Device {
     void emit_offsets() {
       if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
 	emit_compat();
-	emit_offset("MSIP_BASE", 0x0);
-	emit_offset("MTIMECMP_BASE", 0x4000);
-	emit_offset("MTIME", 0xBFF8);
+	emit_offset(METAL_MSIP_BASE_LABEL, 0x0);
+	emit_offset(METAL_MTIMECMP_BASE_LABEL, 0x4000);
+	emit_offset(METAL_MTIME_LABEL, 0xBFF8);
 
 	os << std::endl;
       }

--- a/bare_header/riscv_plic0.h
+++ b/bare_header/riscv_plic0.h
@@ -25,8 +25,8 @@ class riscv_plic0 : public Device {
 	  emit_base(n);
 	  emit_size(n);
 
-	  emit_property_u32(n, "RISCV_MAX_PRIORITY", n.get_field<uint32_t>("riscv,max-priority"));
-	  emit_property_u32(n, "RISCV_NDEV", n.get_field<uint32_t>("riscv,ndev") + 1);
+	  emit_property_u32(n, METAL_RISCV_MAX_PRIORITY_LABEL, n.get_field<uint32_t>("riscv,max-priority"));
+	  emit_property_u32(n, METAL_RISCV_NDEV_LABEL, n.get_field<uint32_t>("riscv,ndev") + 1);
 
 	  os << std::endl;
 	});

--- a/bare_header/riscv_plic0.h
+++ b/bare_header/riscv_plic0.h
@@ -1,0 +1,49 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* This is a device template. Copy and extend it to add more devices. */
+
+#ifndef __BARE_HEADER_RISCV_PLIC0__H
+#define __BARE_HEADER_RISCV_PLIC0__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class riscv_plic0 : public Device {
+  public:
+    riscv_plic0(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "riscv,plic0")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  emit_property_u32(n, "RISCV_MAX_PRIORITY", n.get_field<uint32_t>("riscv,max-priority"));
+	  emit_property_u32(n, "RISCV_NDEV", n.get_field<uint32_t>("riscv,ndev") + 1);
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+	emit_offset("PRIORITY_BASE", 0x0);
+	emit_offset("PENDING_BASE", 0x1000);
+	emit_offset("ENABLE_BASE", 0x2000);
+	emit_offset("THRESHOLD", 0x200000);
+	emit_offset("CLAIM", 0x200004);
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/riscv_pmp.h
+++ b/bare_header/riscv_pmp.h
@@ -20,7 +20,7 @@ class riscv_pmp : public Device {
 	[&](node n) {
 	  emit_comment(n);
 
-	  emit_property_u32(n, "NUM_REGIONS", n.get_field<uint32_t>("regions"));
+	  emit_property_u32(n, METAL_NUM_REGIONS_LABEL, n.get_field<uint32_t>("regions"));
 
 	  os << std::endl;
 	});

--- a/bare_header/riscv_pmp.h
+++ b/bare_header/riscv_pmp.h
@@ -1,0 +1,38 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_RISCV_PMP__H
+#define __BARE_HEADER_RISCV_PMP__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class riscv_pmp : public Device {
+  public:
+    riscv_pmp(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "riscv,pmp")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_property_u32(n, "NUM_REGIONS", n.get_field<uint32_t>("regions"));
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/sifive_clic0.h
+++ b/bare_header/sifive_clic0.h
@@ -23,9 +23,9 @@ class sifive_clic0 : public Device {
 	  emit_base(n);
 	  emit_size(n);
 
-	  emit_property_u32(n, "SIFIVE_NUMINTS", n.get_field<uint32_t>("sifive,numints"));
-	  emit_property_u32(n, "SIFIVE_NUMLEVELS", n.get_field<uint32_t>("sifive,numlevels"));
-	  emit_property_u32(n, "SIFIVE_NUMINTBITS", n.get_field<uint32_t>("sifive,numintbits"));
+	  emit_property_u32(n, METAL_SIFIVE_NUMINTS_LABEL, n.get_field<uint32_t>("sifive,numints"));
+	  emit_property_u32(n, METAL_SIFIVE_NUMLEVELS_LABEL, n.get_field<uint32_t>("sifive,numlevels"));
+	  emit_property_u32(n, METAL_SIFIVE_NUMINTBITS_LABEL, n.get_field<uint32_t>("sifive,numintbits"));
 
 	  os << std::endl;
 	});

--- a/bare_header/sifive_clic0.h
+++ b/bare_header/sifive_clic0.h
@@ -1,0 +1,57 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_SIFIVE_CLIC0__H
+#define __BARE_HEADER_SIFIVE_CLIC0__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class sifive_clic0 : public Device {
+  public:
+    sifive_clic0(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "sifive,clic0")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  emit_property_u32(n, "SIFIVE_NUMINTS", n.get_field<uint32_t>("sifive,numints"));
+	  emit_property_u32(n, "SIFIVE_NUMLEVELS", n.get_field<uint32_t>("sifive,numlevels"));
+	  emit_property_u32(n, "SIFIVE_NUMINTBITS", n.get_field<uint32_t>("sifive,numintbits"));
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+
+	emit_offset("MSIP_BASE",     0x0);
+	emit_offset("MTIMECMP_BASE", 0x4000);
+	emit_offset("MTIME",         0xBFF8);
+
+	emit_offset("CLICINTIP_BASE",  0x0);
+	emit_offset("CLICINTIE_BASE",  0x400);
+	emit_offset("CLICINTCTL_BASE", 0x800);
+	emit_offset("CLICCFG",         0xC00);
+
+	emit_offset("MMODE_APERTURE",  0x800000);
+	emit_offset("HSMODE_APERTURE", 0xA00000);
+	emit_offset("SMODE_APERTURE",  0xC00000);
+	emit_offset("UMODE_APERTURE",  0xE00000);
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/sifive_fe310_g000_prci.h
+++ b/bare_header/sifive_fe310_g000_prci.h
@@ -56,10 +56,10 @@ class sifive_fe310_g000_prci : public Device {
     void emit_offsets() {
       if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
 	emit_compat();
-	emit_offset("HFROSCCFG", 0x0);
-	emit_offset("HFXOSCCFG", 0x4);
-	emit_offset("PLLCFG", 0x8);
-	emit_offset("PLLOUTDIV", 0xC);
+	emit_offset(METAL_HFROSCCFG_LABEL, 0x0);
+	emit_offset(METAL_HFXOSCCFG_LABEL, 0x4);
+	emit_offset(METAL_PLLCFG_LABEL, 0x8);
+	emit_offset(METAL_PLLOUTDIV_LABEL, 0xC);
 
 	os << std::endl;
       }

--- a/bare_header/sifive_fe310_g000_prci.h
+++ b/bare_header/sifive_fe310_g000_prci.h
@@ -1,0 +1,69 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* This is a device template. Copy and extend it to add more devices. */
+
+#ifndef __BARE_HEADER_SIFIVE_FE310_G000_PRCI__H
+#define __BARE_HEADER_SIFIVE_FE310_G000_PRCI__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class sifive_fe310_g000_prci : public Device {
+  public:
+    sifive_fe310_g000_prci(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "sifive,fe310-g000,prci")
+    {}
+
+    uint64_t base_address(const node &n) {
+      uint64_t b;
+
+      n.named_tuples(
+	"reg-names", "reg",
+	"mem", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
+	    b = base;
+	});
+
+      return b;
+    }
+
+    uint64_t size(const node &n) {
+      uint64_t s;
+
+      n.named_tuples(
+	"reg-names", "reg",
+	"mem", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
+	    s = size;
+      });
+
+      return s;
+    }
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+	emit_offset("HFROSCCFG", 0x0);
+	emit_offset("HFXOSCCFG", 0x4);
+	emit_offset("PLLCFG", 0x8);
+	emit_offset("PLLOUTDIV", 0xC);
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/sifive_gpio0.h
+++ b/bare_header/sifive_gpio0.h
@@ -1,0 +1,57 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_SIFIVE_GPIO0__H
+#define __BARE_HEADER_SIFIVE_GPIO0__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class sifive_gpio0 : public Device {
+  public:
+    sifive_gpio0(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "sifive,gpio0")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+	emit_offset("VALUE", 0x0);
+	emit_offset("INPUT_EN", 0x4);
+	emit_offset("OUTPUT_EN", 0x8);
+	emit_offset("PORT", 0xC);
+	emit_offset("PUE", 0x10);
+	emit_offset("DS", 0x14);
+	emit_offset("RISE_IE", 0x18);
+	emit_offset("RISE_IP", 0x1C);
+	emit_offset("FALL_IE", 0x20);
+	emit_offset("FALL_IP", 0x24);
+	emit_offset("HIGH_IE", 0x28);
+	emit_offset("HIGH_IP", 0x2C);
+	emit_offset("LOW_IE", 0x30);
+	emit_offset("LOW_IP", 0x34);
+	emit_offset("IOF_EN", 0x38);
+	emit_offset("IOF_SEL", 0x3C);
+	emit_offset("OUT_XOR", 0x40);
+
+	os << std::endl;
+      }
+    }
+
+};
+
+#endif

--- a/bare_header/sifive_spi0.h
+++ b/bare_header/sifive_spi0.h
@@ -1,0 +1,59 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_SIFIVE_SPI0__H
+#define __BARE_HEADER_SIFIVE_SPI0__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class sifive_spi0 : public Device {
+  public:
+    sifive_spi0(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "sifive,spi0")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+	emit_offset("SCKDIV", 0x0);
+	emit_offset("SCKMODE", 0x4);
+	emit_offset("CSID", 0x10);
+	emit_offset("CSDEF", 0x14);
+	emit_offset("CSMODE", 0x18);
+	emit_offset("DELAY0", 0x28);
+	emit_offset("DELAY1", 0x2C);
+	emit_offset("FMT", 0x40);
+	emit_offset("TXDATA", 0x48);
+	emit_offset("RXDATA", 0x4C);
+	emit_offset("TXMARK", 0x50);
+	emit_offset("RXMARK", 0x54);
+
+	/* TODO: Only include if the device supports a direct-map flash interface */
+	emit_offset("FCTRL", 0x60);
+	emit_offset("FFMT", 0x64);
+
+	emit_offset("IE", 0x70);
+	emit_offset("IP", 0x74);
+
+	os << std::endl;
+      }
+    }
+
+};
+
+#endif

--- a/bare_header/sifive_test0.h
+++ b/bare_header/sifive_test0.h
@@ -1,0 +1,41 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_SIFIVE_TEST0__H
+#define __BARE_HEADER_SIFIVE_TEST0__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class sifive_test0 : public Device {
+  public:
+    sifive_test0(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "sifive,test0")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+
+	emit_offset("FINISHER_OFFSET", 0x0);
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/sifive_uart0.h
+++ b/bare_header/sifive_uart0.h
@@ -1,0 +1,46 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_SIFIVE_UART0__H
+#define __BARE_HEADER_SIFIVE_UART0__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class sifive_uart0 : public Device {
+  public:
+    sifive_uart0(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "sifive,uart0")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+	emit_offset("TXDATA", 0x0);
+	emit_offset("RXDATA", 0x4);
+	emit_offset("TXCTRL", 0x8);
+	emit_offset("RXCTRL", 0xC);
+	emit_offset("IE", 0x10);
+	emit_offset("IP", 0x14);
+	emit_offset("DIV", 0x18);
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/bare_header/template_device.h
+++ b/bare_header/template_device.h
@@ -1,0 +1,45 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* This is a device template. Copy and extend it to add more devices. */
+
+#ifndef __BARE_HEADER_TEMPLATE_DEVICE__H
+#define __BARE_HEADER_TEMPLATE_DEVICE__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+
+class template_device : public Device {
+  public:
+    template_device(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "template_device")
+    {}
+
+    void emit_defines() {
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  emit_comment(n);
+
+	  emit_base(n);
+	  emit_size(n);
+
+	  /* Add more properties here */
+
+	  os << std::endl;
+	});
+    }
+
+    void emit_offsets() {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
+	emit_compat();
+
+	/* Add offsets here */
+
+	os << std::endl;
+      }
+    }
+};
+
+#endif

--- a/header-labels.h
+++ b/header-labels.h
@@ -1,0 +1,43 @@
+/* Copyright (c) 2019 SiFive Inc. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __HEADER_LABELS__H
+#define __HEADER_LABELS__H
+
+/* This file contains the suffixes for the "bare header" #defines so that
+ * they can be kept synchronized between freedom-bare_header-generator and
+ * freedom-metal_header-generator. */
+
+/* Generic Devices */
+#define METAL_BASE_ADDRESS_LABEL "BASE_ADDRESS"
+#define METAL_SIZE_LABEL "SIZE" 
+
+/* Clocks */
+#define METAL_CLOCK_FREQUENCY_LABEL "CLOCK_FREQUENCY"
+#define METAL_CLOCK_DIV_LABEL "CLOCK_DIV"
+#define METAL_CLOCK_MULT_LABEL "CLOCK_MULT"
+
+/* FE310-G000 PRCI */
+#define METAL_HFROSCCFG_LABEL "HFROSCCFG"
+#define METAL_HFXOSCCFG_LABEL "HFXOSCCFG"
+#define METAL_PLLCFG_LABEL "PLLCFG"
+#define METAL_PLLOUTDIV_LABEL "PLLOUTDIV"
+
+/* CLINT */
+#define METAL_MSIP_BASE_LABEL "MSIP_BASE"
+#define METAL_MTIMECMP_BASE_LABEL "MTIMECMP_BASE"
+#define METAL_MTIME_LABEL "MTIME"
+
+/* PLIC */
+#define METAL_RISCV_MAX_PRIORITY_LABEL "RISCV_MAX_PRIORITY"
+#define METAL_RISCV_NDEV_LABEL "RISCV_NDEV"
+
+/* PMP */
+#define METAL_NUM_REGIONS_LABEL "NUM_REGIONS"
+
+/* CLIC */
+#define METAL_SIFIVE_NUMINTS_LABEL "SIFIVE_NUMINTS"
+#define METAL_SIFIVE_NUMLEVELS_LABEL "SIFIVE_NUMLEVELS"
+#define METAL_SIFIVE_NUMINTBITS_LABEL "SIFIVE_NUMINTBITS"
+
+#endif /* __HEADER_LABELS__H */

--- a/metal_header/device.c++
+++ b/metal_header/device.c++
@@ -89,6 +89,45 @@ void Device::emit_struct_field_ts(std::string field, target_size value) {
   os << "    ." << field << " = " << std::to_string(value) << "UL,\n";
 }
 
+void Device::emit_struct_field_platform_define(std::string field, node n, std::string suffix) {
+  auto to_define = [](std::string input_string) -> std::string {
+    std::string s = input_string;
+    std::transform(s.begin(), s.end(), s.begin(),
+      [](unsigned char c) -> char { 
+	if(c == ',' || c == '-') {
+	  return '_';
+	}
+	return toupper(c);
+    });
+
+    return s;
+  };
+  std::string name = to_define(n.get_fields<std::string>("compatible")[0]);
+  std::string instance = to_define(n.instance());
+  suffix = to_define(suffix);
+
+  os << "    ." << field << " = METAL_" << name << "_" << instance << "_" << suffix << "," << std::endl; 
+}
+
+void Device::emit_struct_field_platform_define_offset(std::string field, node n, std::string suffix) {
+  auto to_define = [](std::string input_string) -> std::string {
+    std::string s = input_string;
+    std::transform(s.begin(), s.end(), s.begin(),
+      [](unsigned char c) -> char { 
+	if(c == ',' || c == '-') {
+	  return '_';
+	}
+	return toupper(c);
+    });
+
+    return s;
+  };
+  std::string name = to_define(n.get_fields<std::string>("compatible")[0]);
+  suffix = to_define(suffix);
+
+  os << "    ." << field << " = METAL_" << name << "_" << suffix << "," << std::endl; 
+}
+
 void Device::emit_struct_container_node_and_array(int size, std::string field1,
 						const node& c, std::string subfield1,
 						std::string field2, uint32_t elem) {

--- a/metal_header/device.h
+++ b/metal_header/device.h
@@ -7,6 +7,8 @@
 #include "fdt.h++"
 #include "libfdt.h++"
 
+#include "header-labels.h"
+
 #include <ostream>
 #include <string>
 

--- a/metal_header/device.h
+++ b/metal_header/device.h
@@ -52,6 +52,8 @@ class Device {
     void emit_struct_field_u32(std::string field, uint32_t value);
     void emit_struct_field_ta(std::string field, target_addr value);
     void emit_struct_field_ts(std::string field, target_size value);
+    void emit_struct_field_platform_define(std::string field, node n, std::string suffix);
+    void emit_struct_field_platform_define_offset(std::string field, node n, std::string suffix);
 
     void emit_struct_container_node_and_array(int size,
 					      std::string field1,

--- a/metal_header/fixed_clock.h
+++ b/metal_header/fixed_clock.h
@@ -37,7 +37,7 @@ class fixed_clock : public Device {
 	  emit_struct_begin("fixed_clock", n);
 	  emit_struct_field("vtable", "&__metal_driver_vtable_fixed_clock");
 	  emit_struct_field("clock.vtable", "&__metal_driver_vtable_fixed_clock.clock");
-	  emit_struct_field_u32("rate", n.get_field<uint32_t>("clock-frequency"));
+	  emit_struct_field_platform_define("rate", n, "CLOCK_FREQUENCY");
 	  emit_struct_end();
 	});
     }

--- a/metal_header/fixed_clock.h
+++ b/metal_header/fixed_clock.h
@@ -37,7 +37,7 @@ class fixed_clock : public Device {
 	  emit_struct_begin("fixed_clock", n);
 	  emit_struct_field("vtable", "&__metal_driver_vtable_fixed_clock");
 	  emit_struct_field("clock.vtable", "&__metal_driver_vtable_fixed_clock.clock");
-	  emit_struct_field_platform_define("rate", n, "CLOCK_FREQUENCY");
+	  emit_struct_field_platform_define("rate", n, METAL_CLOCK_FREQUENCY_LABEL);
 	  emit_struct_end();
 	});
     }

--- a/metal_header/fixed_factor_clock.h
+++ b/metal_header/fixed_factor_clock.h
@@ -52,8 +52,8 @@ class fixed_factor_clock : public Device {
 	      emit_struct_field_node("parent", c, ".clock");
 	    });
 
-	  emit_struct_field("mult", std::to_string(n.get_field<uint32_t>("clock-mult")));
-	  emit_struct_field("div", std::to_string(n.get_field<uint32_t>("clock-div")));
+	  emit_struct_field_platform_define("mult", n, "CLOCK_MULT");
+	  emit_struct_field_platform_define("div", n, "CLOCK_DIV");
 
 	  emit_struct_end();
 	});

--- a/metal_header/fixed_factor_clock.h
+++ b/metal_header/fixed_factor_clock.h
@@ -52,8 +52,8 @@ class fixed_factor_clock : public Device {
 	      emit_struct_field_node("parent", c, ".clock");
 	    });
 
-	  emit_struct_field_platform_define("mult", n, "CLOCK_MULT");
-	  emit_struct_field_platform_define("div", n, "CLOCK_DIV");
+	  emit_struct_field_platform_define("mult", n, METAL_CLOCK_MULT_LABEL);
+	  emit_struct_field_platform_define("div", n, METAL_CLOCK_DIV_LABEL);
 
 	  emit_struct_end();
 	});

--- a/metal_header/freedom-metal_header-generator.c++
+++ b/metal_header/freedom-metal_header-generator.c++
@@ -86,6 +86,8 @@ static void write_config_file(const fdt &dtb, fstream &os, std::string cfg_file)
   os << "#ifndef " << cfg_file << std::endl;
   os << "#define " << cfg_file << std::endl << std::endl;
 
+  os << "#include <metal/machine/platform.h>" << std::endl << std::endl;
+
   std::list<Device *> devices;
 
   /* Generic Devices */

--- a/metal_header/riscv_clint0.h
+++ b/metal_header/riscv_clint0.h
@@ -91,12 +91,8 @@ class riscv_clint0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_riscv_clint0");
 	  emit_struct_field("controller.vtable", "&__metal_driver_vtable_riscv_clint0.clint_vtable");
 
-	  n.named_tuples(
-	    "reg-names", "reg",
-	    "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
-	      emit_struct_field_ta("control_base", base);
-	      emit_struct_field_ts("control_size", size);
-	    });
+	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
+	  emit_struct_field_platform_define("control_size", n, "SIZE");
 
 	  emit_struct_field("init_done", "0");
 	  emit_struct_field("num_interrupts", "METAL_MAX_CLINT_INTERRUPTS");

--- a/metal_header/riscv_clint0.h
+++ b/metal_header/riscv_clint0.h
@@ -91,8 +91,8 @@ class riscv_clint0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_riscv_clint0");
 	  emit_struct_field("controller.vtable", "&__metal_driver_vtable_riscv_clint0.clint_vtable");
 
-	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
-	  emit_struct_field_platform_define("control_size", n, "SIZE");
+	  emit_struct_field_platform_define("control_base", n, METAL_BASE_ADDRESS_LABEL);
+	  emit_struct_field_platform_define("control_size", n, METAL_SIZE_LABEL);
 
 	  emit_struct_field("init_done", "0");
 	  emit_struct_field("num_interrupts", "METAL_MAX_CLINT_INTERRUPTS");

--- a/metal_header/riscv_plic0.h
+++ b/metal_header/riscv_plic0.h
@@ -119,16 +119,11 @@ class riscv_plic0 : public Device {
 		os << "    .interrupt_lines[" + std::to_string(i) + "] = " + std::to_string(line) + ",\n";
 	    });
 
-	  n.named_tuples(
-	    "reg-names", "reg",
-	    "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
-	      emit_struct_field_ta("control_base", base);
-	      emit_struct_field_ts("control_size", size);
-	    });
+	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
+	  emit_struct_field_platform_define("control_size", n, "SIZE");
 
-	  emit_struct_field_u32("max_priority", n.get_field<uint32_t>("riscv,max-priority"));
-          /* Add 1 to number of interrupts for 0 base software index */
-	  emit_struct_field_u32("num_interrupts", n.get_field<uint32_t>("riscv,ndev") + 1);
+	  emit_struct_field_platform_define("max_priority", n, "riscv,max-priority");
+	  emit_struct_field_platform_define("num_interrupts", n, "riscv,ndev");
 
 	  if (n.field_exists("interrupt-controller")) { 
 	      emit_struct_field("interrupt_controller", "1");

--- a/metal_header/riscv_plic0.h
+++ b/metal_header/riscv_plic0.h
@@ -119,11 +119,11 @@ class riscv_plic0 : public Device {
 		os << "    .interrupt_lines[" + std::to_string(i) + "] = " + std::to_string(line) + ",\n";
 	    });
 
-	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
-	  emit_struct_field_platform_define("control_size", n, "SIZE");
+	  emit_struct_field_platform_define("control_base", n, METAL_BASE_ADDRESS_LABEL);
+	  emit_struct_field_platform_define("control_size", n, METAL_SIZE_LABEL);
 
-	  emit_struct_field_platform_define("max_priority", n, "riscv,max-priority");
-	  emit_struct_field_platform_define("num_interrupts", n, "riscv,ndev");
+	  emit_struct_field_platform_define("max_priority", n, METAL_RISCV_MAX_PRIORITY_LABEL);
+	  emit_struct_field_platform_define("num_interrupts", n, METAL_RISCV_NDEV_LABEL);
 
 	  if (n.field_exists("interrupt-controller")) { 
 	      emit_struct_field("interrupt_controller", "1");

--- a/metal_header/riscv_pmp.h
+++ b/metal_header/riscv_pmp.h
@@ -37,7 +37,7 @@ class riscv_pmp : public Device {
 	[&](node n) {
 	  emit_comment(n);
 	  os << "struct metal_pmp __metal_dt_" << n.handle() << " = {\n";
-	  emit_struct_field_u32("num_regions", n.get_field<uint32_t>("regions"));
+	  emit_struct_field_platform_define("num_regions", n, "NUM_REGIONS");
 	  emit_struct_end();
 	});
     }

--- a/metal_header/riscv_pmp.h
+++ b/metal_header/riscv_pmp.h
@@ -37,7 +37,7 @@ class riscv_pmp : public Device {
 	[&](node n) {
 	  emit_comment(n);
 	  os << "struct metal_pmp __metal_dt_" << n.handle() << " = {\n";
-	  emit_struct_field_platform_define("num_regions", n, "NUM_REGIONS");
+	  emit_struct_field_platform_define("num_regions", n, METAL_NUM_REGIONS_LABEL);
 	  emit_struct_end();
 	});
     }

--- a/metal_header/sifive_clic0.h
+++ b/metal_header/sifive_clic0.h
@@ -82,12 +82,8 @@ class sifive_clic0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_clic0");
 	  emit_struct_field("controller.vtable", "&__metal_driver_vtable_sifive_clic0.clic_vtable");
 
-	  n.named_tuples(
-	    "reg-names", "reg",
-	    "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
-	      emit_struct_field_ta("control_base", base);
-	      emit_struct_field_ts("control_size", size);
-	    });
+	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
+	  emit_struct_field_platform_define("control_size", n, "SIZE");
 
 	  emit_struct_field("init_done", "0");
 	  emit_struct_field("num_interrupts", "METAL_MAX_CLIC_INTERRUPTS");
@@ -103,9 +99,9 @@ class sifive_clic0 : public Device {
 						     "interrupt_lines", line);
 	    });
 
-	  emit_struct_field_u32("num_subinterrupts", n.get_field<uint32_t>("sifive,numints"));
-	  emit_struct_field_u32("num_intbits", n.get_field<uint32_t>("sifive,numintbits"));
-	  emit_struct_field_u32("max_levels", n.get_field<uint32_t>("sifive,numlevels"));
+	  emit_struct_field_platform_define("num_subinterrupts", n, "SIFIVE_NUMINTS");
+	  emit_struct_field_platform_define("num_intbits", n, "SIFIVE_NUMINTBITS");
+	  emit_struct_field_platform_define("max_levels", n, "SIFIVE_NUMLEVELS");
 
 	  if (n.field_exists("interrupt-controller")) {
 	      emit_struct_field("interrupt_controller", "1");

--- a/metal_header/sifive_clic0.h
+++ b/metal_header/sifive_clic0.h
@@ -82,8 +82,8 @@ class sifive_clic0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_clic0");
 	  emit_struct_field("controller.vtable", "&__metal_driver_vtable_sifive_clic0.clic_vtable");
 
-	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
-	  emit_struct_field_platform_define("control_size", n, "SIZE");
+	  emit_struct_field_platform_define("control_base", n, METAL_BASE_ADDRESS_LABEL);
+	  emit_struct_field_platform_define("control_size", n, METAL_SIZE_LABEL);
 
 	  emit_struct_field("init_done", "0");
 	  emit_struct_field("num_interrupts", "METAL_MAX_CLIC_INTERRUPTS");
@@ -99,9 +99,9 @@ class sifive_clic0 : public Device {
 						     "interrupt_lines", line);
 	    });
 
-	  emit_struct_field_platform_define("num_subinterrupts", n, "SIFIVE_NUMINTS");
-	  emit_struct_field_platform_define("num_intbits", n, "SIFIVE_NUMINTBITS");
-	  emit_struct_field_platform_define("max_levels", n, "SIFIVE_NUMLEVELS");
+	  emit_struct_field_platform_define("num_subinterrupts", n, METAL_SIFIVE_NUMINTS_LABEL);
+	  emit_struct_field_platform_define("num_intbits", n, METAL_SIFIVE_NUMINTBITS_LABEL);
+	  emit_struct_field_platform_define("max_levels", n, METAL_SIFIVE_NUMLEVELS_LABEL);
 
 	  if (n.field_exists("interrupt-controller")) {
 	      emit_struct_field("interrupt_controller", "1");

--- a/metal_header/sifive_fe310_g000_hfrosc.h
+++ b/metal_header/sifive_fe310_g000_hfrosc.h
@@ -49,7 +49,7 @@ class sifive_fe310_g000_hfrosc : public Device {
 	    "reg-names", "reg",
 	    "config", tuple_t<node, target_size>(), [&](node base, target_size offset) {
 	      emit_struct_field_node("config_base", base, "");
-	      emit_struct_field_platform_define_offset("config_offset", base, "HFROSCCFG");
+	      emit_struct_field_platform_define_offset("config_offset", base, METAL_HFROSCCFG_LABEL);
 	  });
 
 	  emit_struct_end();

--- a/metal_header/sifive_fe310_g000_hfrosc.h
+++ b/metal_header/sifive_fe310_g000_hfrosc.h
@@ -49,7 +49,7 @@ class sifive_fe310_g000_hfrosc : public Device {
 	    "reg-names", "reg",
 	    "config", tuple_t<node, target_size>(), [&](node base, target_size offset) {
 	      emit_struct_field_node("config_base", base, "");
-	      emit_struct_field_ts("config_offset", offset);
+	      emit_struct_field_platform_define_offset("config_offset", base, "HFROSCCFG");
 	  });
 
 	  emit_struct_end();

--- a/metal_header/sifive_fe310_g000_hfxosc.h
+++ b/metal_header/sifive_fe310_g000_hfxosc.h
@@ -49,7 +49,7 @@ class sifive_fe310_g000_hfxosc : public Device {
 	    "reg-names", "reg",
 	    "config", tuple_t<node, target_size>(), [&](node base, target_size offset) {
 	      emit_struct_field_node("config_base", base, "");
-	      emit_struct_field_platform_define_offset("config_offset", base, "HFXOSCCFG");
+	      emit_struct_field_platform_define_offset("config_offset", base, METAL_HFXOSCCFG_LABEL);
 	  });
 
 	  emit_struct_end();

--- a/metal_header/sifive_fe310_g000_hfxosc.h
+++ b/metal_header/sifive_fe310_g000_hfxosc.h
@@ -49,7 +49,7 @@ class sifive_fe310_g000_hfxosc : public Device {
 	    "reg-names", "reg",
 	    "config", tuple_t<node, target_size>(), [&](node base, target_size offset) {
 	      emit_struct_field_node("config_base", base, "");
-	      emit_struct_field_ts("config_offset", offset);
+	      emit_struct_field_platform_define_offset("config_offset", base, "HFXOSCCFG");
 	  });
 
 	  emit_struct_end();

--- a/metal_header/sifive_fe310_g000_pll.h
+++ b/metal_header/sifive_fe310_g000_pll.h
@@ -56,11 +56,11 @@ class sifive_fe310_g000_pll : public Device {
 	    "reg-names", "reg",
 	    "config", tuple_t<node, target_size>(), [&](node base, target_size off) {
 	      emit_struct_field_node("config_base", base, "");
-	      emit_struct_field_ts("config_offset", off);
+	      emit_struct_field_platform_define_offset("config_offset", base, "PLLCFG");
 	    },
 	    "divider", tuple_t<node, target_size>(), [&](node base, target_size off) {
 	      emit_struct_field_node("divider_base", base, "");
-	      emit_struct_field_ts("divider_offset", off);
+	      emit_struct_field_platform_define_offset("divider_offset", base, "PLLOUTDIV");
 	    });
 
 	  emit_struct_field_u32("init_rate", n.get_field<uint32_t>("clock-frequency"));

--- a/metal_header/sifive_fe310_g000_pll.h
+++ b/metal_header/sifive_fe310_g000_pll.h
@@ -56,11 +56,11 @@ class sifive_fe310_g000_pll : public Device {
 	    "reg-names", "reg",
 	    "config", tuple_t<node, target_size>(), [&](node base, target_size off) {
 	      emit_struct_field_node("config_base", base, "");
-	      emit_struct_field_platform_define_offset("config_offset", base, "PLLCFG");
+	      emit_struct_field_platform_define_offset("config_offset", base, METAL_PLLCFG_LABEL);
 	    },
 	    "divider", tuple_t<node, target_size>(), [&](node base, target_size off) {
 	      emit_struct_field_node("divider_base", base, "");
-	      emit_struct_field_platform_define_offset("divider_offset", base, "PLLOUTDIV");
+	      emit_struct_field_platform_define_offset("divider_offset", base, METAL_PLLOUTDIV_LABEL);
 	    });
 
 	  emit_struct_field_u32("init_rate", n.get_field<uint32_t>("clock-frequency"));

--- a/metal_header/sifive_fe310_g000_prci.h
+++ b/metal_header/sifive_fe310_g000_prci.h
@@ -42,12 +42,8 @@ class sifive_fe310_g000_prci : public Device {
 
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_fe310_g000_prci");
 
-	  n.named_tuples(
-	    "reg-names", "reg",
-	    "mem", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
-	      emit_struct_field_ta("base", base);
-	      emit_struct_field_ts("size", size);
-	  });
+	  emit_struct_field_platform_define("base", n, "BASE_ADDRESS");
+	  emit_struct_field_platform_define("size", n, "SIZE");
 
 	  emit_struct_end();
 	});

--- a/metal_header/sifive_fe310_g000_prci.h
+++ b/metal_header/sifive_fe310_g000_prci.h
@@ -42,8 +42,8 @@ class sifive_fe310_g000_prci : public Device {
 
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_fe310_g000_prci");
 
-	  emit_struct_field_platform_define("base", n, "BASE_ADDRESS");
-	  emit_struct_field_platform_define("size", n, "SIZE");
+	  emit_struct_field_platform_define("base", n, METAL_BASE_ADDRESS_LABEL);
+	  emit_struct_field_platform_define("size", n, METAL_SIZE_LABEL);
 
 	  emit_struct_end();
 	});

--- a/metal_header/sifive_gpio0.h
+++ b/metal_header/sifive_gpio0.h
@@ -72,8 +72,8 @@ class sifive_gpio0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_gpio0");
 	  emit_struct_field("gpio.vtable", "&__metal_driver_vtable_sifive_gpio0.gpio");
 
-	  emit_struct_field_platform_define("base", n, "BASE_ADDRESS");
-	  emit_struct_field_platform_define("size", n, "SIZE");
+	  emit_struct_field_platform_define("base", n, METAL_BASE_ADDRESS_LABEL);
+	  emit_struct_field_platform_define("size", n, METAL_SIZE_LABEL);
 
 	  n.maybe_tuple(
 	    "interrupt-parent", tuple_t<node>(),

--- a/metal_header/sifive_gpio0.h
+++ b/metal_header/sifive_gpio0.h
@@ -72,12 +72,8 @@ class sifive_gpio0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_gpio0");
 	  emit_struct_field("gpio.vtable", "&__metal_driver_vtable_sifive_gpio0.gpio");
 
-	  n.named_tuples(
-	    "reg-names", "reg",
-	    "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
-	      emit_struct_field_ta("base", base);
-	      emit_struct_field_ts("size", size);
-	    });
+	  emit_struct_field_platform_define("base", n, "BASE_ADDRESS");
+	  emit_struct_field_platform_define("size", n, "SIZE");
 
 	  n.maybe_tuple(
 	    "interrupt-parent", tuple_t<node>(),

--- a/metal_header/sifive_spi0.h
+++ b/metal_header/sifive_spi0.h
@@ -53,12 +53,8 @@ class sifive_spi0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_spi0");
 	  emit_struct_field("spi.vtable", "&__metal_driver_vtable_sifive_spi0.spi");
 
-	  n.named_tuples(
-	    "reg-names", "reg",
-	    "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
-	      emit_struct_field_ta("control_base", base);
-	      emit_struct_field_ts("control_size", size);
-	    });
+	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
+	  emit_struct_field_platform_define("control_size", n, "SIZE");
 
 	  n.maybe_tuple(
 	    "clocks", tuple_t<node>(),

--- a/metal_header/sifive_spi0.h
+++ b/metal_header/sifive_spi0.h
@@ -53,8 +53,8 @@ class sifive_spi0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_spi0");
 	  emit_struct_field("spi.vtable", "&__metal_driver_vtable_sifive_spi0.spi");
 
-	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
-	  emit_struct_field_platform_define("control_size", n, "SIZE");
+	  emit_struct_field_platform_define("control_base", n, METAL_BASE_ADDRESS_LABEL);
+	  emit_struct_field_platform_define("control_size", n, METAL_SIZE_LABEL);
 
 	  n.maybe_tuple(
 	    "clocks", tuple_t<node>(),

--- a/metal_header/sifive_uart0.h
+++ b/metal_header/sifive_uart0.h
@@ -62,8 +62,8 @@ class sifive_uart0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_uart0");
 	  emit_struct_field("uart.vtable", "&__metal_driver_vtable_sifive_uart0.uart");
 
-	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
-	  emit_struct_field_platform_define("control_size", n, "SIZE");
+	  emit_struct_field_platform_define("control_base", n, METAL_BASE_ADDRESS_LABEL);
+	  emit_struct_field_platform_define("control_size", n, METAL_SIZE_LABEL);
 
 	  n.maybe_tuple(
 	    "clocks", tuple_t<node>(),

--- a/metal_header/sifive_uart0.h
+++ b/metal_header/sifive_uart0.h
@@ -62,12 +62,8 @@ class sifive_uart0 : public Device {
 	  emit_struct_field("vtable", "&__metal_driver_vtable_sifive_uart0");
 	  emit_struct_field("uart.vtable", "&__metal_driver_vtable_sifive_uart0.uart");
 
-	  n.named_tuples(
-	    "reg-names", "reg",
-	    "control", tuple_t<target_addr, target_size>(), [&](target_addr base, target_size size) {
-	      emit_struct_field_ta("control_base", base);
-	      emit_struct_field_ts("control_size", size);
-	    });
+	  emit_struct_field_platform_define("control_base", n, "BASE_ADDRESS");
+	  emit_struct_field_platform_define("control_size", n, "SIZE");
 
 	  n.maybe_tuple(
 	    "clocks", tuple_t<node>(),


### PR DESCRIPTION
The bare header contains:
- Device MMIO base address and size
- Device properties
- Device MMIO register offsets

Also update the metal header generator to use the output of the bare header generator in device structs.