### PR TITLE
Add Release Tag and timestamp during release time

### DIFF
--- a/bare_header/freedom-bare_header-generator.c++
+++ b/bare_header/freedom-bare_header-generator.c++
@@ -53,10 +53,12 @@ static void write_banner(fstream &os, std::string rel_tag)
   os << "/* Copyright 2019 SiFive, Inc */" << std::endl;
   os << "/* SPDX-License-Identifier: Apache-2.0 */" << std::endl;
   os << "/* ----------------------------------- */" << std::endl;
-  auto t = std::time(nullptr);
-  auto tm = *std::localtime(&t);
-  os << "/* [" << (rel_tag.empty() ? "XXXXX" : rel_tag) << "] "
-     << std::put_time(&tm, "%d-%m-%Y %H-%M-%S") << "        */" << std::endl;
+  if ( !rel_tag.empty() ) {
+    auto t = std::time(nullptr);
+    auto tm = *std::localtime(&t);
+    os << "/* [" << rel_tag << "] "
+       << std::put_time(&tm, "%d-%m-%Y %H-%M-%S") << "        */" << std::endl;
+  }
   os << "/* ----------------------------------- */" << std::endl << std::endl;
 }
 

--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -50,10 +50,12 @@ static void write_banner(fstream &os, std::string rel_tag)
   os << "/* Copyright 2019 SiFive, Inc */" << std::endl;
   os << "/* SPDX-License-Identifier: Apache-2.0 */" << std::endl;
   os << "/* ----------------------------------- */" << std::endl;
-  auto t = std::time(nullptr);
-  auto tm = *std::localtime(&t);
-  os << "/* [" << (rel_tag.empty() ? "XXXXX" : rel_tag) << "] "
-     << std::put_time(&tm, "%d-%m-%Y %H-%M-%S") << "        */" << std::endl;
+  if ( !rel_tag.empty() ) {
+    auto t = std::time(nullptr);
+    auto tm = *std::localtime(&t);
+    os << "/* [" << rel_tag << "] "
+       << std::put_time(&tm, "%d-%m-%Y %H-%M-%S") << "        */" << std::endl;
+  }
   os << "/* ----------------------------------- */" << std::endl << std::endl;
 }
 

--- a/freedom-makeattributes-generator.c++
+++ b/freedom-makeattributes-generator.c++
@@ -58,10 +58,12 @@ static void write_banner(fstream &os, std::string rel_tag)
   os << "# Copyright 2019 SiFive, Inc #" << std::endl;
   os << "# SPDX-License-Identifier: Apache-2.0 #" << std::endl;
   os << "# ----------------------------------- #" << std::endl;
-  auto t = std::time(nullptr);
-  auto tm = *std::localtime(&t);
-  os << "# [" << (rel_tag.empty() ? "XXXXX" : rel_tag) << "] "
-     << std::put_time(&tm, "%d-%m-%Y %H-%M-%S") << "        #" << std::endl;
+  if ( !rel_tag.empty() ) {
+    auto t = std::time(nullptr);
+    auto tm = *std::localtime(&t);
+    os << "# [" << rel_tag << "] "
+       << std::put_time(&tm, "%d-%m-%Y %H-%M-%S") << "        #" << std::endl;
+  }
   os << "# ----------------------------------- #" << std::endl << std::endl;
 }
 

--- a/metal_header/freedom-metal_header-generator.c++
+++ b/metal_header/freedom-metal_header-generator.c++
@@ -59,10 +59,12 @@ static void write_banner(fstream &os, std::string rel_tag)
   os << "/* Copyright 2019 SiFive, Inc */" << std::endl;
   os << "/* SPDX-License-Identifier: Apache-2.0 */" << std::endl;
   os << "/* ----------------------------------- */" << std::endl;
-  auto t = std::time(nullptr);
-  auto tm = *std::localtime(&t);
-  os << "/* [" << (rel_tag.empty() ? "XXXXX" : rel_tag) << "] "
-     << std::put_time(&tm, "%d-%m-%Y %H-%M-%S") << "        */" << std::endl;
+  if ( !rel_tag.empty() ) {
+    auto t = std::time(nullptr);
+    auto tm = *std::localtime(&t);
+    os << "/* [" << rel_tag << "] "
+       << std::put_time(&tm, "%d-%m-%Y %H-%M-%S") << "        */" << std::endl;
+  }
   os << "/* ----------------------------------- */" << std::endl << std::endl;
 }
 

--- a/metal_header/sifive_local_external_interrupts0.h
+++ b/metal_header/sifive_local_external_interrupts0.h
@@ -10,11 +10,20 @@
 
 class sifive_local_external_interrupts0 : public Device {
   public:
+    int num_local_ext_ints = 0;
     uint32_t max_interrupts = 0;
 
     sifive_local_external_interrupts0(std::ostream &os, const fdt &dtb)
       : Device(os, dtb, "sifive,local-external-interrupts0")
-    {}
+    {
+      /* Count the number of Lobal External Interrupts0 */
+      num_local_ext_ints = 0;
+      dtb.match(
+	std::regex(compat_string),
+	[&](node n) {
+	  num_local_ext_ints += 1;
+	});
+    }
 
     void create_defines()
     {
@@ -152,14 +161,18 @@ class sifive_local_external_interrupts0 : public Device {
 	      }
 	    },
 	    [&](int i, uint32_t irline){
-	      if (i == 0) {
+	      if ((count == 0) && (i == 0)) {
 		func = create_inline_def("interrupt_lines",
 					 "int",
 					 "idx == " + std::to_string(i),
 					 std::to_string(irline),
 					 "struct metal_interrupt *controller", "int idx");
+		if (((count + 1) == num_local_ext_ints) &&
+		    ((i + 1) == max_interrupts)) {
+		      add_inline_body(func, "else", "0");
+		}
 		extern_inlines.push_back(func);
-	      } else if ((i + 1) == max_interrupts) {
+              } else if (((count + 1) == num_local_ext_ints) && ((i + 1) == max_interrupts)) {
 		add_inline_body(func, "idx == " + std::to_string(i), std::to_string(irline));
 		add_inline_body(func, "else", "0");
 	      } else {

--- a/multilib.h++
+++ b/multilib.h++
@@ -6,16 +6,26 @@
 
 std::string arch2arch(std::string arch)
 {
+    if (arch == "rv32e")      return "rv32e";
+    if (arch == "rv32em")     return "rv32em";
+    if (arch == "rv32eac")    return "rv32eac";
+    if (arch == "rv32emac")   return "rv32emac";
+    if (arch == "rv32emafc")  return "rv32emafc";
+    if (arch == "rv32emafdc") return "rv32emafdc";
     if (arch == "rv32i")      return "rv32i";
     if (arch == "rv32im")     return "rv32im";
     if (arch == "rv32imc")    return "rv32imc";
     if (arch == "rv32iac")    return "rv32iac";
     if (arch == "rv32imac")   return "rv32imac";
     if (arch == "rv32imafc")  return "rv32imafc";
-    if (arch == "rv64imac")   return "rv64imac";
-    if (arch == "rv64imafdc") return "rv64imafdc";
-
     if (arch == "rv32imafdc") return "rv32imafdc";
+    if (arch == "rv64i")      return "rv64i";
+    if (arch == "rv64im")     return "rv64im";
+    if (arch == "rv64imc")    return "rv64imc";
+    if (arch == "rv64iac")    return "rv64iac";
+    if (arch == "rv64imac")   return "rv64imac";
+    if (arch == "rv64imafc")  return "rv64imafc";
+    if (arch == "rv64imafdc") return "rv64imafdc";
 
     std::cerr << "arch2arch(): unknown arch " << arch << std::endl;
     abort();
@@ -24,16 +34,26 @@ std::string arch2arch(std::string arch)
 
 std::string arch2abi(std::string arch)
 {
+    if (arch == "rv32e")      return "ilp32e";
+    if (arch == "rv32em")     return "ilp32e";
+    if (arch == "rv32eac")    return "ilp32e";
+    if (arch == "rv32emac")   return "ilp32e";
+    if (arch == "rv32emafc")  return "ilp32f";
+    if (arch == "rv32emafdc") return "ilp32d";
     if (arch == "rv32i")      return "ilp32";
     if (arch == "rv32im")     return "ilp32";
     if (arch == "rv32imc")    return "ilp32";
     if (arch == "rv32iac")    return "ilp32";
     if (arch == "rv32imac")   return "ilp32";
     if (arch == "rv32imafc")  return "ilp32f";
+    if (arch == "rv32imafdc") return "ilp32d";
+    if (arch == "rv64i")      return "lp64";
+    if (arch == "rv64im")     return "lp64";
+    if (arch == "rv64imc")    return "lp64";
+    if (arch == "rv64iac")    return "lp64";
     if (arch == "rv64imac")   return "lp64";
+    if (arch == "rv64imafc")  return "lp64f";
     if (arch == "rv64imafdc") return "lp64d";
-
-    if (arch == "rv32imafdc") return "ilp32f";
 
     std::cerr << "arch2abi(): unknown arch " << arch << std::endl;
     abort();

--- a/tests/e34-eval-makeattributes.bash
+++ b/tests/e34-eval-makeattributes.bash
@@ -14,7 +14,7 @@ then
     exit 1
 fi
 
-if [[ "$(cat e34-eval-build.env | grep RISCV_ABI=ilp32f | wc -l)" == 0 ]]
+if [[ "$(cat e34-eval-build.env | grep RISCV_ABI=ilp32d | wc -l)" == 0 ]]
 then
     echo "wrong mabi"
     exit 1

--- a/tests/e34-eval-metal_specs.bash
+++ b/tests/e34-eval-metal_specs.bash
@@ -16,7 +16,7 @@ then
     exit 1
 fi
 
-if [[ "$(cat e34-eval-build.env | grep mabi=ilp32f | wc -l)" == 0 ]]
+if [[ "$(cat e34-eval-build.env | grep mabi=ilp32d | wc -l)" == 0 ]]
 then
     echo "wrong mabi"
     exit 1


### PR DESCRIPTION
This PR disable the release tag and timestamp update to generated files.
Release tag will only be added if -r "Tag Label" is given.

While at it also fix a bug in Global and Local External interrupts inline uncover during spanning config testing.