### PR TITLE
Revert "Check first for the presence of a memory node"

### DIFF
--- a/freedom-ldscript-generator.c++
+++ b/freedom-ldscript-generator.c++
@@ -398,12 +398,7 @@ static void dts_memory (bool ramrodata)
                 });
         });
 
-    if (memory_count > 0) {
-        alias_memory("memory", "ram");
-    	if (spi_count > 0) {
-            alias_memory("spi", "flash");
-        }
-    } else if (ahb_periph_count > 0) {
+    if (ahb_periph_count > 0) {
         if (sram_count > 1) {
             alias_memory("sram0", "ram");
             alias_memory("sram1", "itim");
@@ -525,6 +520,11 @@ static void dts_memory (bool ramrodata)
             alias_memory("testram", "flash");
         } else {
             alias_memory("testram", "ram");
+        }
+    } else if (memory_count > 0) {
+        alias_memory("memory", "ram");
+    	if (spi_count > 0) {
+            alias_memory("spi", "flash");
         }
     } else if (sram_count > 0) {
         if (sram_count == 1 && ramrodata) {


### PR DESCRIPTION
Reverts sifive/freedom-devicetree-tools#89