### PR TITLE
Add additional supported ISA extension subsets

### DIFF
--- a/multilib.h++
+++ b/multilib.h++
@@ -7,12 +7,14 @@
 std::string arch2arch(std::string arch)
 {
     if (arch == "rv32e")      return "rv32e";
+    if (arch == "rv32ec")     return "rv32ec";
     if (arch == "rv32em")     return "rv32em";
     if (arch == "rv32eac")    return "rv32eac";
     if (arch == "rv32emac")   return "rv32emac";
     if (arch == "rv32emafc")  return "rv32emafc";
     if (arch == "rv32emafdc") return "rv32emafdc";
     if (arch == "rv32i")      return "rv32i";
+    if (arch == "rv32ic")     return "rv32ic";
     if (arch == "rv32im")     return "rv32im";
     if (arch == "rv32imc")    return "rv32imc";
     if (arch == "rv32iac")    return "rv32iac";
@@ -20,12 +22,17 @@ std::string arch2arch(std::string arch)
     if (arch == "rv32imafc")  return "rv32imafc";
     if (arch == "rv32imafdc") return "rv32imafdc";
     if (arch == "rv64i")      return "rv64i";
+    if (arch == "rv64ic")     return "rv64ic";
     if (arch == "rv64im")     return "rv64im";
     if (arch == "rv64imc")    return "rv64imc";
     if (arch == "rv64iac")    return "rv64iac";
     if (arch == "rv64imac")   return "rv64imac";
     if (arch == "rv64imafc")  return "rv64imafc";
     if (arch == "rv64imafdc") return "rv64imafdc";
+
+    /* These architectures are not currently supported by the toolchain's multilibs */
+    if (arch == "rv32imf")    return "rv32im";
+    if (arch == "rv64imf")    return "rv64im";
 
     std::cerr << "arch2arch(): unknown arch " << arch << std::endl;
     abort();
@@ -35,12 +42,14 @@ std::string arch2arch(std::string arch)
 std::string arch2abi(std::string arch)
 {
     if (arch == "rv32e")      return "ilp32e";
+    if (arch == "rv32ec")     return "ilp32e";
     if (arch == "rv32em")     return "ilp32e";
     if (arch == "rv32eac")    return "ilp32e";
     if (arch == "rv32emac")   return "ilp32e";
     if (arch == "rv32emafc")  return "ilp32f";
     if (arch == "rv32emafdc") return "ilp32d";
     if (arch == "rv32i")      return "ilp32";
+    if (arch == "rv32ic")     return "ilp32";
     if (arch == "rv32im")     return "ilp32";
     if (arch == "rv32imc")    return "ilp32";
     if (arch == "rv32iac")    return "ilp32";
@@ -48,12 +57,17 @@ std::string arch2abi(std::string arch)
     if (arch == "rv32imafc")  return "ilp32f";
     if (arch == "rv32imafdc") return "ilp32d";
     if (arch == "rv64i")      return "lp64";
+    if (arch == "rv64ic")     return "lp64";
     if (arch == "rv64im")     return "lp64";
     if (arch == "rv64imc")    return "lp64";
     if (arch == "rv64iac")    return "lp64";
     if (arch == "rv64imac")   return "lp64";
     if (arch == "rv64imafc")  return "lp64f";
     if (arch == "rv64imafdc") return "lp64d";
+
+    /* These architectures are not currently supported by the toolchain's multilibs */
+    if (arch == "rv32imf")    return "ilp32";
+    if (arch == "rv64imf")    return "lp64";
 
     std::cerr << "arch2abi(): unknown arch " << arch << std::endl;
     abort();


### PR DESCRIPTION
Adds support for
- rv32ec
- rv32ic
- rv64ic

Also adds ISA subsets are not currently represented by multilibs, mapped
to supported march/mabi pairs.

Includes:
- rv32imf -> rv32im/ilp32
- rv64imf -> rv64im/lp64