### PR TITLE
include sstream in files that use istringstream

### DIFF
--- a/bare_header/freedom-bare_header-generator.c++
+++ b/bare_header/freedom-bare_header-generator.c++
@@ -7,6 +7,7 @@
 
 /* STL */
 #include <fstream>
+#include <sstream>
 #include <iostream>
 #include <map>
 #include <list>

--- a/metal_header/freedom-metal_header-generator.c++
+++ b/metal_header/freedom-metal_header-generator.c++
@@ -42,6 +42,7 @@
 
 /* STL */
 #include <fstream>
+#include <sstream>
 #include <iostream>
 #include <map>
 #include <list>


### PR DESCRIPTION
Compilation succeeds on ubuntu 16.04 but fails on mac os due to missing headers. Including `sstream` fixes it for me.