### PR TITLE
Fix OpenOCD config generator on e20 arty

### DIFF
--- a/freedom-openocdcfg-generator.c++
+++ b/freedom-openocdcfg-generator.c++
@@ -373,7 +373,7 @@ static void dts_memory (void)
     
     if (memory_count > 0) {
       alias_memory("memory", "ram");
-    } else if (sram_count > 1) {
+    } else if (sram_count > 0) {
       alias_memory("sram", "ram");
     } else if (dtim_count > 0) {
       alias_memory("dtim", "ram");


### PR DESCRIPTION
Only require 1 sram to alias it to ram