### PR TITLE
Check code model support of selected memory layout

### DIFF
--- a/linker_script/map_strategy.c++
+++ b/linker_script/map_strategy.c++
@@ -1,20 +1,38 @@
 /* Copyright (c) 2019 SiFive Inc. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <iostream>
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
 #include <iomanip>
-#include <string>
+#include <iostream>
 #include <regex>
+#include <string>
 
 #include "map_strategy.h"
 
+using std::cerr;
 using std::cout;
 using std::dec;
 using std::endl;
 using std::hex;
+using std::max;
+using std::max_element;
+using std::min;
+using std::min_element;
 using std::regex;
 using std::setw;
 using std::string;
+using std::transform;
+
+/* MEDLOW_MIN and MEDLOW_MAX are the inclusive extrema of the range of
+ * addresses reachable with a signed 32-bit offset from address 0 */
+#define MEDLOW_MIN ((uint64_t) INT32_MIN)
+#define MEDLOW_MAX ((uint64_t) INT32_MAX)
+
+/* MEDANY_RANGE is the maximum addressable distance between two symbols in the
+ * medany code model outside of the medlow-addressable range */
+#define MEDANY_RANGE ((uint64_t) INT32_MAX)
 
 /* TestRam Compatible Strings
  *
@@ -40,7 +58,143 @@ static list<string> testram_compats = {
   "sifive,mem-port",
 };
 
-void MapStrategy::print_chosen_strategy(string name, LinkStrategy layout,
+static int get_xlen(const fdt &dtb) {
+  int boothartid = 0;
+  dtb.chosen(
+    "metal,boothart",
+    tuple_t<node>(),
+    [&](node n) {
+      boothartid = std::stoi(n.instance());
+    });
+
+  node boothart = dtb.node_by_path("/cpus/cpu@" + std::to_string(boothartid));
+
+  if (boothart.field_exists("riscv,isa")) {
+    string isa = boothart.get_field<string>("riscv,isa");
+    if(isa.find("rv32") != string::npos) {
+      return 32;
+    } else if (isa.find("rv64") != string::npos) {
+      return 64;
+    }
+  }
+
+  cerr << "ERROR: Unable to determine XLEN of target" << endl;
+  exit(1);
+
+  return 0;
+}
+
+static bool memory_in_medlow(Memory m) {
+  const int64_t base = (int64_t)m.base;
+  const int64_t top = ((int64_t)m.base + m.size - 1);
+
+  return (base >= MEDLOW_MIN) && (top <= MEDLOW_MAX);
+}
+
+static bool check_base_addr_distance(Memory a, Memory b) {
+  return ((max(a.base, b.base) - min(a.base, b.base)) < MEDANY_RANGE);
+}
+
+static void warn_medany_reachability(Memory a, Memory b) {
+  const uint64_t base_a = max(a.base, MEDLOW_MAX + 1);
+  const uint64_t base_b = max(b.base, MEDLOW_MAX + 1);
+
+  const uint64_t top_a = min((uint64_t)((int64_t)a.base + a.size - 1), MEDLOW_MIN - 1);
+  const uint64_t top_b = min((uint64_t)((int64_t)b.base + b.size - 1), MEDLOW_MIN - 1);
+
+  if (a.base > b.base) {
+    if ((top_a - base_b) > MEDANY_RANGE) {
+      cerr << hex;
+      cerr << "WARNING: not all of the memory in '" << a.compatible << "' @ 0x" \
+           << a.base << " will be addressable with the medany code model" << endl;
+      cerr << dec;
+    }
+  } else if (b.base > a.base){
+    if ((top_b - base_a) > MEDANY_RANGE) {
+      cerr << hex;
+      cerr << "WARNING: not all of the memory in '" << b.compatible << "' @ 0x" \
+           << b.base << " will be addressable with the medany code model" << endl;
+      cerr << dec;
+    }
+  }
+}
+
+bool MapStrategy::check_cmodel_support(const fdt &dtb, CodeModel cmodel, Memory ram, Memory rom, Memory itim)
+{
+  /* Any 32-bit design should support any existing code model. */
+  if (get_xlen(dtb) == 64) {
+    bool rom_in_medlow = memory_in_medlow(rom);
+    bool ram_in_medlow = memory_in_medlow(ram);
+    bool itim_in_medlow = memory_in_medlow(itim);
+
+    switch (cmodel) {
+    default:
+      return false;
+    case CODE_MODEL_MEDLOW:
+      return (rom_in_medlow && ram_in_medlow && itim_in_medlow);
+    case CODE_MODEL_MEDANY:
+        if (rom_in_medlow && ram_in_medlow && itim_in_medlow) {
+          /* If the memories are all addressable my medlow, they're addressable
+           * by medany */
+          return true;
+
+        } else if (ram_in_medlow) {
+          if ( ! (rom_in_medlow && itim_in_medlow) ) {
+            /* Print a warning if the entire rom and itim can't be used by
+             * PC-relative addressing */
+            warn_medany_reachability(rom, itim);
+          }
+
+          /* If the rom and/or the itim are not addressable by medlow, then
+           * they just need to be close enough together for PC-relative
+           * addressing */
+          return check_base_addr_distance(rom, itim);
+
+        } else {
+          /* Print a warning if the entire ram can't be used by PC-relative
+           * addressing */
+          if (rom.base > itim.base) {
+            warn_medany_reachability(ram, itim);
+          } else {
+            warn_medany_reachability(ram, rom);
+          }
+
+          /* If the ram is not addressable by medlow, then the ram needs to
+           * be close enough to both the rom and the itim */
+          return (check_base_addr_distance(ram, rom) && check_base_addr_distance(ram, itim));
+        }
+      break;
+    }
+  }
+
+  return true;
+}
+
+void MapStrategy::check_all_cmodels(const fdt &dtb, Memory ram, Memory rom, Memory itim)
+{
+  bool supported = false;
+
+  if (check_cmodel_support(dtb, CODE_MODEL_MEDLOW, ram, rom, itim)) {
+    supported = true;
+  } else {
+    cerr << "WARNING: the 'medlow' code model is not supported on this target" << endl;
+  }
+
+  if (check_cmodel_support(dtb, CODE_MODEL_MEDANY, ram, rom, itim)) {
+    supported = true;
+  } else {
+    cerr << "WARNING: the 'medany' code model is not supported on this target" << endl;
+  }
+
+  if (!supported) {
+    cerr << "ERROR: no code models are supported on this target" << endl;
+    cerr << "ERROR: the memory map must be changed to support building C code" << endl;
+    exit(1);
+  }
+}
+
+void MapStrategy::print_chosen_strategy(const fdt &dtb, string name,
+                                        LinkStrategy layout,
                                         Memory ram, Memory rom, Memory itim)
 {
   cout << hex;
@@ -63,6 +217,11 @@ void MapStrategy::print_chosen_strategy(string name, LinkStrategy layout,
   cout << "\tROM:  " << setw(25) << rom.compatible << " - 0x" << rom.base << endl;
   cout << "\tITIM: " << setw(25) << itim.compatible << " - 0x" << itim.base << endl;
   cout << dec;
+
+  /* We've identified the memories to be used and are telling the user about it.
+   * Now seems like a good time to warn them about code model support and crash
+   * if none are supported. */
+  check_all_cmodels(dtb, ram, rom, itim);
 }
 
 bool MapStrategy::has_testram(list<Memory> memories) {

--- a/linker_script/map_strategy.h
+++ b/linker_script/map_strategy.h
@@ -21,16 +21,51 @@ typedef enum {
   LINK_STRATEGY_RAMRODATA,
 } LinkStrategy;
 
+typedef enum {
+  CODE_MODEL_MEDLOW,
+  CODE_MODEL_MEDANY,
+} CodeModel;
+
 class MapStrategy {
   public:
-    void print_chosen_strategy(string name, LinkStrategy layout, Memory ram, Memory rom, Memory itim);
+    /*!
+     * @brief Check if a list of memories will be compatible with a given code model
+     */
+    bool check_cmodel_support(const fdt &dtb, CodeModel cmodel, Memory ram, Memory rom, Memory itim);
 
-    /* Generic helpers for identifying testrams */
+    /*!
+     * @brief Check if the memory map is supported by any code model
+     *
+     * Prints warnings to stderr if a code model is not supported.
+     * Exits with an error code if no code model is supported.
+     */
+    void check_all_cmodels(const fdt &dtb, Memory ram, Memory rom, Memory itim);
+
+    /*!
+     * @brief Print the details of the chosen strategy to stdout
+     */
+    void print_chosen_strategy(const fdt &dtb, string name,
+                               LinkStrategy layout,
+                               Memory ram, Memory rom, Memory itim);
+
+    /*!
+     * @brief Detects if a memory corresponding to an RTL reset vector exists
+     */
     bool has_testram(list<Memory> memories);
+
+    /*!
+     * @brief Returns the memory which is selected by RTL reset vector heuristics
+     */
     Memory find_testram(list<Memory> memories);
 
+    /*!
+     * @brief Detects if the MapStrategy is valid for the list of available memories
+     */
     virtual bool valid(const fdt &dtb, list<Memory> available_memories) = 0;
 
+    /*!
+     * @brief builds a LinkerScript using the available memories for the strategy
+     */
     virtual LinkerScript create_layout(const fdt &dtb, list<Memory> available_memories,
                                        LinkStrategy link_strategy) = 0;
 };

--- a/linker_script/strategies/chosen_strategy.c++
+++ b/linker_script/strategies/chosen_strategy.c++
@@ -96,9 +96,9 @@ LinkerScript ChosenStrategy::create_layout(const fdt &dtb, list<Memory> availabl
   /* Generate the layouts */
 
   if (has_itim) {
-    print_chosen_strategy("ChosenStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
+    print_chosen_strategy(dtb, "ChosenStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
   } else {
-    print_chosen_strategy("ChosenStrategy", link_strategy, ram_memory, rom_memory, ram_memory);
+    print_chosen_strategy(dtb, "ChosenStrategy", link_strategy, ram_memory, rom_memory, ram_memory);
   }
 
   switch (link_strategy) {

--- a/linker_script/strategies/default_bullet_arty.c++
+++ b/linker_script/strategies/default_bullet_arty.c++
@@ -55,7 +55,7 @@ LinkerScript DefaultBulletArtyStrategy::create_layout(const fdt &dtb, list<Memor
   }
 
   /* Generate the layouts */
-  print_chosen_strategy("DefaultBulletArtyStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
+  print_chosen_strategy(dtb, "DefaultBulletArtyStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
 
   switch (link_strategy) {
   default:

--- a/linker_script/strategies/default_bullet_strategy.c++
+++ b/linker_script/strategies/default_bullet_strategy.c++
@@ -49,7 +49,7 @@ LinkerScript DefaultBulletStrategy::create_layout(const fdt &dtb, list<Memory> a
   }
 
   /* Generate the layouts */
-  print_chosen_strategy("DefaultBulletStrategy", link_strategy, rom_memory, rom_memory, itim_memory);
+  print_chosen_strategy(dtb, "DefaultBulletStrategy", link_strategy, rom_memory, rom_memory, itim_memory);
 
   switch (link_strategy) {
   default:

--- a/linker_script/strategies/default_e20_arty_strategy.c++
+++ b/linker_script/strategies/default_e20_arty_strategy.c++
@@ -43,7 +43,7 @@ LinkerScript DefaultE20ArtyStrategy::create_layout(const fdt &dtb, list<Memory> 
   }
 
   /* Generate the layouts */
-  print_chosen_strategy("DefaultE20ArtyStrategy", link_strategy, ram_memory, rom_memory, ram_memory);
+  print_chosen_strategy(dtb, "DefaultE20ArtyStrategy", link_strategy, ram_memory, rom_memory, ram_memory);
 
   switch (link_strategy) {
   default:

--- a/linker_script/strategies/default_e20_strategy.c++
+++ b/linker_script/strategies/default_e20_strategy.c++
@@ -20,7 +20,7 @@ LinkerScript DefaultE20Strategy::create_layout(const fdt &dtb, list<Memory> avai
   rom_memory.attributes = "wxa!ri";
 
   /* Generate the layouts */
-  print_chosen_strategy("DefaultE20Strategy", link_strategy, rom_memory, rom_memory, rom_memory);
+  print_chosen_strategy(dtb, "DefaultE20Strategy", link_strategy, rom_memory, rom_memory, rom_memory);
 
   switch (link_strategy) {
   default:

--- a/linker_script/strategies/default_e21_arty_strategy.c++
+++ b/linker_script/strategies/default_e21_arty_strategy.c++
@@ -58,7 +58,7 @@ LinkerScript DefaultE21ArtyStrategy::create_layout(const fdt &dtb, list<Memory> 
   }
 
   /* Generate the layouts */
-  print_chosen_strategy("DefaultE21ArtyStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
+  print_chosen_strategy(dtb, "DefaultE21ArtyStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
 
   switch (link_strategy) {
   default:

--- a/linker_script/strategies/default_e21_strategy.c++
+++ b/linker_script/strategies/default_e21_strategy.c++
@@ -55,7 +55,7 @@ LinkerScript DefaultE21Strategy::create_layout(const fdt &dtb, list<Memory> avai
   }
 
   /* Generate the layouts */
-  print_chosen_strategy("DefaultE21Strategy", link_strategy, ram_memory, rom_memory, itim_memory);
+  print_chosen_strategy(dtb, "DefaultE21Strategy", link_strategy, ram_memory, rom_memory, itim_memory);
 
   switch (link_strategy) {
   default:

--- a/linker_script/strategies/default_rocket_arty.c++
+++ b/linker_script/strategies/default_rocket_arty.c++
@@ -53,7 +53,7 @@ LinkerScript DefaultRocketArtyStrategy::create_layout(const fdt &dtb, list<Memor
     itim_memory = ram_memory;
   }
 
-  print_chosen_strategy("DefaultRocketArtyStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
+  print_chosen_strategy(dtb, "DefaultRocketArtyStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
 
   switch (link_strategy) {
   default:

--- a/linker_script/strategies/default_rocket_strategy.c++
+++ b/linker_script/strategies/default_rocket_strategy.c++
@@ -50,7 +50,7 @@ LinkerScript DefaultRocketStrategy::create_layout(const fdt &dtb, list<Memory> a
     itim_memory = ram_memory;
   }
 
-  print_chosen_strategy("DefaultRocketStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
+  print_chosen_strategy(dtb, "DefaultRocketStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
 
   switch (link_strategy) {
   default:

--- a/linker_script/strategies/template_strategy.c++
+++ b/linker_script/strategies/template_strategy.c++
@@ -43,7 +43,7 @@ LinkerScript TemplateStrategy::create_layout(const fdt &dtb, list<Memory> availa
   }
 
   /* Generate the layouts */
-  print_chosen_strategy("TemplateStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
+  print_chosen_strategy(dtb, "TemplateStrategy", link_strategy, ram_memory, rom_memory, itim_memory);
 
   switch (link_strategy) {
   default:


### PR DESCRIPTION
After the memory layout has been selected, check for code model support and provide warnings if any are unsupported. If no code model is supported, fail.