### PR TITLE
Also use sifive,sram0 for ITIM in targets with a memory port

### DIFF
--- a/linker_script/strategies/default_bullet_arty.c++
+++ b/linker_script/strategies/default_bullet_arty.c++
@@ -41,7 +41,7 @@ LinkerScript DefaultBulletArtyStrategy::create_layout(const fdt &dtb, list<Memor
       rom_memory = *it;
       rom_memory.name = "flash";
       rom_memory.attributes = "rxai!w";
-    } else if ((*it).compatible == "sifive,itim0") {
+    } else if ((*it).compatible == "sifive,itim0" || it->compatible == "sifive,sram0") {
       itim_memory = *it;
       itim_memory.name = "itim";
       itim_memory.attributes = "wx!rai";

--- a/linker_script/strategies/default_bullet_strategy.c++
+++ b/linker_script/strategies/default_bullet_strategy.c++
@@ -40,7 +40,7 @@ LinkerScript DefaultBulletStrategy::create_layout(const fdt &dtb, list<Memory> a
       ram_memory = *it;
       ram_memory.name = "ram";
       ram_memory.attributes = "wxa!ri";
-    } else if ((*it).compatible == "sifive,itim0") {
+    } else if ((*it).compatible == "sifive,itim0" || it->compatible == "sifive,sram0") {
       itim_memory = *it;
       itim_memory.name = "itim";
       itim_memory.attributes = "wx!rai";


### PR DESCRIPTION
Some targets identify their ITIM with the compatible string "sifive,sram0".