### PR TITLE
Fix duplicated index for filter condition

### DIFF
--- a/metal_header/riscv_cpu.c++
+++ b/metal_header/riscv_cpu.c++
@@ -123,13 +123,11 @@ void riscv_cpu::define_inlines()
 					   "struct metal_cpu *cpu");
 	extern_inlines.push_back(func_pmpregions);
 
-      }
-      if ((count + 1) == num_cpus) {
+      } else if ((count + 1) == num_cpus) {
 	add_inline_body(func_hartid, "else", "-1");
 	add_inline_body(func_tf, "else", "0");
 	add_inline_body(func_ic, "else", "NULL");
 	add_inline_body(func_pmpregions, "else", "0");
-
       } else {
 	add_inline_body(func_hartid,
 			"(uintptr_t)cpu == (uintptr_t)&__metal_dt_" + n.handle(),

--- a/metal_header/riscv_plic0.c++
+++ b/metal_header/riscv_plic0.c++
@@ -242,8 +242,7 @@ void riscv_plic0::define_inlines()
 				     std::to_string(irline),
 				     "struct metal_interrupt *controller", "int idx");
 	    extern_inlines.push_back(funcl);
-	  }
-	  if ((i + 1) == max_interrupts) {
+	  } else if ((i + 1) == max_interrupts) {
 	    add_inline_body(func, "idx == " + std::to_string(i), value);
 	    add_inline_body(func, "else", "NULL");
 


### PR DESCRIPTION
In some functions of CPU and PLIC, the if-else condtion was duplicated, such as 'idx == 0' be checked twice.