### PR TITLE
Fix l2 cache controller issue

### DIFF
--- a/bare_header/sifive_fu540_c000_l2.h
+++ b/bare_header/sifive_fu540_c000_l2.h
@@ -15,12 +15,12 @@ class sifive_fu540_c000_l2 : public Device {
     {}
 
     int get_index(const node &n) {
-      return Device::get_index(n, "sifive,ccache0");
+      return Device::get_index(n, compat_string);
     }
 
     void emit_defines() {
       dtb.match(
-	std::regex("sifive,ccache0"),
+	std::regex(compat_string),
 	[&](node n) {
 	  emit_comment(n);
 
@@ -32,9 +32,8 @@ class sifive_fu540_c000_l2 : public Device {
     }
 
     void emit_offsets() {
-      if(dtb.match(std::regex("sifive,ccache0"), [](const node n){}) != 0) {
+      if(dtb.match(std::regex(compat_string), [](const node n){}) != 0) {
 	emit_compat();
-
 	emit_offset(METAL_SIFIVE_FU540_C000_L2_CONFIG_LABEL, 0x0);
 	emit_offset(METAL_SIFIVE_FU540_C000_L2_WAYENABLE_LABEL, 0x8);
 

--- a/metal_header/sifive_fu540_c000_l2.c++
+++ b/metal_header/sifive_fu540_c000_l2.c++
@@ -111,7 +111,7 @@ void sifive_fu540_c000_l2::create_handles()
   dtb.match(
     std::regex(compat_string),
     [&](node n) {
-      emit_def_handle("__METAL_DT_SIFIVE_FU540_C000_L2_HANDLE", n, "");
+      emit_def_handle("__METAL_DT_SIFIVE_FU540_C000_L2_HANDLE", n, ".cache");
     });
 }
 

--- a/metal_header/sifive_fu540_c000_l2.c++
+++ b/metal_header/sifive_fu540_c000_l2.c++
@@ -57,17 +57,13 @@ void sifive_fu540_c000_l2::define_inlines()
     std::regex(compat_string),
     [&](node n) {
       if (count == 0) {
-	n.named_tuples(
-	  "reg-names", "reg",
-	  "config", tuple_t<node>(), [&](node m) {
-	  func = create_inline_def("control_base",
-				   "uintptr_t",
-				   "(uintptr_t)cache == (uintptr_t)&__metal_dt_" + n.handle(),
-				   "&__metal_dt_" + m.handle(),
-				   "struct metal_cache *cache");
-	  add_inline_body(func, "else", "NULL");
-	  extern_inlines.push_back(func);
-	  });
+	func = create_inline_def("control_base",
+				 "uintptr_t",
+				 "(uintptr_t)cache == (uintptr_t)&__metal_dt_" + n.handle(),
+				 platform_define(n, METAL_BASE_ADDRESS_LABEL),
+				 "struct metal_cache *cache");
+	add_inline_body(func, "else", "0");
+	extern_inlines.push_back(func);
       }
     count++;
     }

--- a/metal_header/sifive_fu540_c000_l2.c++
+++ b/metal_header/sifive_fu540_c000_l2.c++
@@ -12,7 +12,7 @@ sifive_fu540_c000_l2::sifive_fu540_c000_l2(std::ostream &os, const fdt &dtb)
 void sifive_fu540_c000_l2::include_headers()
 {
   dtb.match(
-    std::regex("sifive,ccache0"),
+    std::regex(compat_string),
     [&](node n) {
       emit_include(compat_string);
     });
@@ -86,7 +86,7 @@ void sifive_fu540_c000_l2::define_inlines()
 void sifive_fu540_c000_l2::declare_structs()
 {
   dtb.match(
-    std::regex("sifive,ccache0"),
+    std::regex(compat_string),
     [&](node n) {
       emit_struct_decl("sifive_fu540_c000_l2", n);
     }
@@ -96,7 +96,7 @@ void sifive_fu540_c000_l2::declare_structs()
 void sifive_fu540_c000_l2::define_structs()
 {
   dtb.match(
-    std::regex("sifive,ccache0"),
+    std::regex(compat_string),
     [&](node n) {
       emit_struct_begin("sifive_fu540_c000_l2", n);
 
@@ -109,7 +109,7 @@ void sifive_fu540_c000_l2::define_structs()
 void sifive_fu540_c000_l2::create_handles()
 {
   dtb.match(
-    std::regex("sifive,ccache0"),
+    std::regex(compat_string),
     [&](node n) {
       emit_def_handle("__METAL_DT_SIFIVE_FU540_C000_L2_HANDLE", n, "");
     });


### PR DESCRIPTION
These patches contain generating control_base functions of l2 cache controller and modifying the name of compatible. The compatible of cache controller of design.dts in bsp should be corrected together.
