### PR TITLE
Fix base address extraction in bare header generator

### DIFF
--- a/bare_header/device.c++
+++ b/bare_header/device.c++
@@ -91,8 +91,14 @@ static mem_map_t extract_mem_map(const node &n) {
 
   if(n.field_exists("reg-names")) {
     n.named_tuples(
-      "reg-names",
-      "reg", "mem",
+      "reg-names", "reg",
+      "mem",
+      tuple_t<target_addr, target_size>(),
+      [&](target_addr b, target_size s) {
+	m.base = b;
+	m.size = s;
+      },
+      "control",
       tuple_t<target_addr, target_size>(),
       [&](target_addr b, target_size s) {
 	m.base = b;


### PR DESCRIPTION
Also extract "control" named registers