### PR TITLE
Fix duplicated idx v2

### DIFF
--- a/metal_header/riscv_clint0.c++
+++ b/metal_header/riscv_clint0.c++
@@ -206,15 +206,13 @@ void riscv_clint0::define_inlines()
 				     std::to_string(irline),
 				     "struct metal_interrupt *controller", "int idx");
 	    extern_inlines.push_back(funcl);
-	  } else if ((i + 1) == max_interrupts) {
-	    add_inline_body(func, "idx == " + std::to_string(i), value);
-	    add_inline_body(func, "else", "NULL");
-
-	    add_inline_body(funcl, "idx == " + std::to_string(i), std::to_string(irline));
-	    add_inline_body(funcl, "else", "0");
 	  } else {
 	    add_inline_body(func, "idx == " + std::to_string(i), value);
 	    add_inline_body(funcl, "idx == " + std::to_string(i), std::to_string(irline));
+	  }
+	  if ((i + 1) == max_interrupts) {
+	    add_inline_body(func, "else", "NULL");
+	    add_inline_body(funcl, "else", "0");
 	  }
 	});
 

--- a/metal_header/riscv_cpu.c++
+++ b/metal_header/riscv_cpu.c++
@@ -122,14 +122,6 @@ void riscv_cpu::define_inlines()
 					   std::to_string(num_pmp_regions),
 					   "struct metal_cpu *cpu");
 	extern_inlines.push_back(func_pmpregions);
-
-      }
-      if ((count + 1) == num_cpus) {
-	add_inline_body(func_hartid, "else", "-1");
-	add_inline_body(func_tf, "else", "0");
-	add_inline_body(func_ic, "else", "NULL");
-	add_inline_body(func_pmpregions, "else", "0");
-
       } else {
 	add_inline_body(func_hartid,
 			"(uintptr_t)cpu == (uintptr_t)&__metal_dt_" + n.handle(),
@@ -143,6 +135,12 @@ void riscv_cpu::define_inlines()
 	add_inline_body(func_pmpregions,
 			"(uintptr_t)cpu == (uintptr_t)&__metal_dt_" + n.handle(),
 			std::to_string(num_pmp_regions));
+      }
+      if ((count + 1) == num_cpus) {
+	add_inline_body(func_hartid, "else", "-1");
+	add_inline_body(func_tf, "else", "0");
+	add_inline_body(func_ic, "else", "NULL");
+	add_inline_body(func_pmpregions, "else", "0");
       }
       count++;
     }

--- a/metal_header/riscv_plic0.c++
+++ b/metal_header/riscv_plic0.c++
@@ -242,16 +242,13 @@ void riscv_plic0::define_inlines()
 				     std::to_string(irline),
 				     "struct metal_interrupt *controller", "int idx");
 	    extern_inlines.push_back(funcl);
-	  }
-	  if ((i + 1) == max_interrupts) {
-	    add_inline_body(func, "idx == " + std::to_string(i), value);
-	    add_inline_body(func, "else", "NULL");
-
-	    add_inline_body(funcl, "idx == " + std::to_string(i), std::to_string(irline));
-	    add_inline_body(funcl, "else", "0");
 	  } else {
 	    add_inline_body(func, "idx == " + std::to_string(i), value);
 	    add_inline_body(funcl, "idx == " + std::to_string(i), std::to_string(irline));
+	  }
+	  if ((i + 1) == max_interrupts) {
+	    add_inline_body(func, "else", "NULL");
+	    add_inline_body(funcl, "else", "0");
 	  }
 	});
       count++;


### PR DESCRIPTION
In some functions of CPU and PLIC which generated in the metal.h  header file, the if-else condtions are duplicated such as 'idx == 0'  be checked twice.
In PLIC generator, don't use 'else-if' conditional to filter the max_interrupts condition. It causes dosen't generate tail curly brackets when the value of interrupts-extended property specifying only one contexts.
In CPU generator, don't use 'else-if' conditional to filter the num_cpus condition. It causes dosen't generate tail curly brackets when there is only one cpu node in dts.
There is also a potential bug in clint, I fix it in the riscv_clint.c++ together at this time