### PR TITLE
Fix target/source symbols for data, itim, bss

### DIFF
--- a/linker_script/section.c++
+++ b/linker_script/section.c++
@@ -6,10 +6,16 @@
 Section::Section(Memory logical_memory, Memory virtual_memory,
                  Phdr program_header)
     : logical_memory(logical_memory), virtual_memory(virtual_memory),
-      program_header(program_header) {}
+      program_header(program_header), alignment(0) {}
 
 string Section::describe() {
-  string description = "\t." + output_name + " : {\n";
+  string description;
+  if (alignment == 0) {
+    description = "\t." + output_name + " : {\n";
+  } else {
+    description =
+        "\t." + output_name + " : ALIGN(" + std::to_string(alignment) + ") {\n";
+  }
 
   for (auto it = commands.begin(); it != commands.end(); it++) {
     description += "\t\t" + *it + "\n";

--- a/linker_script/section.h
+++ b/linker_script/section.h
@@ -16,6 +16,7 @@ using std::string;
 class Section {
 public:
   string output_name;
+  int alignment;
   list<string> commands;
   list<string> trailing_commands;
 

--- a/linker_script/sections/data_group.c++
+++ b/linker_script/sections/data_group.c++
@@ -7,28 +7,10 @@ DataGroup::DataGroup(Memory logical_memory, Phdr logical_header,
                      Memory virtual_memory, Phdr virtual_header)
     : SectionGroup(logical_memory, logical_header, virtual_memory,
                    virtual_header) {
-  Section lalign(logical_memory, logical_memory, logical_header);
-
-  lalign.output_name = "lalign";
-
-  lalign.add_command(". = ALIGN(8);");
-  lalign.add_command("PROVIDE( _data_lma = . );");
-  lalign.add_command("PROVIDE( metal_segment_data_source_start = . );");
-
-  sections.push_back(lalign);
-
-  Section dalign(logical_memory, virtual_memory, virtual_header);
-
-  dalign.output_name = "dalign";
-
-  dalign.add_command(". = ALIGN(8);");
-  dalign.add_command("PROVIDE( metal_segment_data_target_start = . );");
-
-  sections.push_back(dalign);
-
   Section data(logical_memory, virtual_memory, virtual_header);
 
   data.output_name = "data";
+  data.alignment = 8;
 
   data.add_command("*(.data .data.*)");
   data.add_command("*(.gnu.linkonce.d.*)");
@@ -45,7 +27,10 @@ DataGroup::DataGroup(Memory logical_memory, Phdr logical_header,
 
   sections.push_back(data);
 
-  trailing_commands.push_back("PROVIDE( _edata = . );");
-  trailing_commands.push_back("PROVIDE( edata = . );");
-  trailing_commands.push_back("PROVIDE( metal_segment_data_target_end = . );");
+  trailing_commands.push_back(
+      "PROVIDE( metal_segment_data_source_start = LOADADDR(.data) );");
+  trailing_commands.push_back(
+      "PROVIDE( metal_segment_data_target_start = ADDR(.data) );");
+  trailing_commands.push_back("PROVIDE( metal_segment_data_target_end = "
+                              "ADDR(.data) + SIZEOF(.data) );");
 }

--- a/linker_script/sections/itim_group.c++
+++ b/linker_script/sections/itim_group.c++
@@ -7,31 +7,19 @@ ItimGroup::ItimGroup(Memory logical_memory, Phdr logical_header,
                      Memory virtual_memory, Phdr virtual_header)
     : SectionGroup(logical_memory, logical_header, virtual_memory,
                    virtual_header) {
-  Section litimalign(logical_memory, logical_memory, logical_header);
-
-  litimalign.output_name = "litimalign";
-
-  litimalign.add_command(". = ALIGN(8);");
-  litimalign.add_command("PROVIDE( metal_segment_itim_source_start = . );");
-
-  sections.push_back(litimalign);
-
-  Section ditimalign(logical_memory, virtual_memory, virtual_header);
-
-  ditimalign.output_name = "ditimalign";
-
-  ditimalign.add_command(". = ALIGN(8);");
-  ditimalign.add_command("PROVIDE( metal_segment_itim_target_start = . );");
-
-  sections.push_back(ditimalign);
-
   Section itim_section(logical_memory, virtual_memory, virtual_header);
 
-  itim_section.output_name = "itim_section";
+  itim_section.output_name = "itim";
+  itim_section.alignment = 8;
 
   itim_section.add_command("*(.itim .itim.*)");
 
   sections.push_back(itim_section);
 
-  trailing_commands.push_back("PROVIDE( metal_segment_itim_target_end = . );");
+  trailing_commands.push_back(
+      "PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );");
+  trailing_commands.push_back(
+      "PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );");
+  trailing_commands.push_back("PROVIDE( metal_segment_itim_target_end = "
+                              "ADDR(.itim) + SIZEOF(.itim) );");
 }

--- a/linker_script/sections/itim_text_group.c++
+++ b/linker_script/sections/itim_text_group.c++
@@ -7,42 +7,24 @@ ItimTextGroup::ItimTextGroup(Memory logical_memory, Phdr logical_header,
                              Memory virtual_memory, Phdr virtual_header)
     : SectionGroup(logical_memory, logical_header, virtual_memory,
                    virtual_header) {
-  Section litimalign(logical_memory, logical_memory, logical_header);
-
-  litimalign.output_name = "litimalign";
-
-  litimalign.add_command(". = ALIGN(8);");
-  litimalign.add_command("PROVIDE( metal_segment_itim_source_start = . );");
-
-  sections.push_back(litimalign);
-
-  Section ditimalign(logical_memory, virtual_memory, virtual_header);
-
-  ditimalign.output_name = "ditimalign";
-
-  ditimalign.add_command(". = ALIGN(8);");
-  ditimalign.add_command("PROVIDE( metal_segment_itim_target_start = . );");
-
-  sections.push_back(ditimalign);
-
-  Section text_section(logical_memory, virtual_memory, virtual_header);
-
-  text_section.output_name = "text";
-
-  text_section.add_command("*(.text.unlikely .text.unlikely.*)");
-  text_section.add_command("*(.text.startup .text.startup.*)");
-  text_section.add_command("*(.text .text.*)");
-  text_section.add_command("*(.gnu.linkonce.t.*)");
-
-  sections.push_back(text_section);
-
   Section itim_section(logical_memory, virtual_memory, virtual_header);
 
-  itim_section.output_name = "itim_section";
+  itim_section.output_name = "itim";
+  itim_section.alignment = 8;
+
+  itim_section.add_command("*(.text.unlikely .text.unlikely.*)");
+  itim_section.add_command("*(.text.startup .text.startup.*)");
+  itim_section.add_command("*(.text .text.*)");
+  itim_section.add_command("*(.gnu.linkonce.t.*)");
 
   itim_section.add_command("*(.itim .itim.*)");
 
   sections.push_back(itim_section);
 
-  trailing_commands.push_back("PROVIDE( metal_segment_itim_target_end = . );");
+  trailing_commands.push_back(
+      "PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );");
+  trailing_commands.push_back(
+      "PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );");
+  trailing_commands.push_back("PROVIDE( metal_segment_itim_target_end = "
+                              "ADDR(.itim) + SIZEOF(.itim) );");
 }

--- a/linker_script/sections/uninit_group.c++
+++ b/linker_script/sections/uninit_group.c++
@@ -15,14 +15,10 @@ UninitGroup::UninitGroup(const fdt &dtb, Memory logical_memory,
   int num_harts = 0;
   dtb.match(regex("cpu"), [&](node n) { num_harts += 1; });
 
-  leading_commands.push_back(". = ALIGN(8);");
-  leading_commands.push_back("PROVIDE( _fbss = . );");
-  leading_commands.push_back("PROVIDE( __bss_start = . );");
-  leading_commands.push_back("PROVIDE( metal_segment_bss_target_start = . );");
-
   Section bss(virtual_memory, virtual_memory, virtual_header);
 
   bss.output_name = "bss";
+  bss.alignment = 8;
 
   bss.add_command("*(.sbss*)");
   bss.add_command("*(.gnu.linkonce.sb.*)");
@@ -30,10 +26,10 @@ UninitGroup::UninitGroup(const fdt &dtb, Memory logical_memory,
   bss.add_command("*(.gnu.linkonce.b.*)");
   bss.add_command("*(COMMON)");
 
-  bss.trailing_commands.push_back("PROVIDE( _end = . );");
-  bss.trailing_commands.push_back("PROVIDE( end = . );");
   bss.trailing_commands.push_back(
-      "PROVIDE( metal_segment_bss_target_end = . );");
+      "PROVIDE( metal_segment_bss_target_start = ADDR(.bss) );");
+  bss.trailing_commands.push_back(
+      "PROVIDE( metal_segment_bss_target_end = ADDR(.bss) + SIZEOF(.bss) );");
 
   sections.push_back(bss);
 


### PR DESCRIPTION
Instead of hoping that the target and source symbols for the beginning
of the data, itim, and bss sections match, explicitly set them to the
LOADADDR and ADDR of the section. This fixes bugs where the linker
decided that, for example, metal_segment_data_source_start doesn't have
to match exactly the load address of the data segment, causing corrupted
data in the running program.