### PR TITLE
Ask for rodata in data section

### DIFF
--- a/linker_script/sections/data_group.c++
+++ b/linker_script/sections/data_group.c++
@@ -24,6 +24,10 @@ DataGroup::DataGroup(Memory logical_memory, Phdr logical_header,
   data.add_command("*(.srodata.cst4)");
   data.add_command("*(.srodata.cst2)");
   data.add_command("*(.srodata .srodata.*)");
+  data.add_command(". = ALIGN(8);");
+  data.add_command("*(.rdata)");
+  data.add_command("*(.rodata .rodata.*)");
+  data.add_command("*(.gnu.linkonce.r.*)");
 
   sections.push_back(data);
 


### PR DESCRIPTION
If the RodataGroup is included first in the layout, then the rodata
sections will still be put in .rodata instead of .data. This makes sure
that the read-only data is still included in ramrodata layouts.