### PR TITLE
Support multi-core of PLIC driver

### DIFF
--- a/bare_header/riscv_plic0.h
+++ b/bare_header/riscv_plic0.h
@@ -37,8 +37,11 @@ public:
       emit_offset("PRIORITY_BASE", 0x0);
       emit_offset("PENDING_BASE", 0x1000);
       emit_offset("ENABLE_BASE", 0x2000);
-      emit_offset("THRESHOLD", 0x200000);
-      emit_offset("CLAIM", 0x200004);
+      emit_offset("ENABLE_PER_HART", 0x80);
+      emit_offset("CONTEXT_BASE", 0x200000);
+      emit_offset("CONTEXT_PER_HART", 0x1000);
+      emit_offset("CONTEXT_THRESHOLD", 0x00);
+      emit_offset("CONTEXT_CLAIM", 0x04);
 
       os << std::endl;
     }

--- a/tests/e51-arty.dts
+++ b/tests/e51-arty.dts
@@ -6,7 +6,7 @@
 	compatible = "SiFive,FE510G-dev", "fe510-dev", "sifive-dev";
 	model = "SiFive,FE510G";
 	L17: cpus {
-		#address-cells = <2>;
+		#address-cells = <1>;
 		#size-cells = <0>;
 		L6: cpu@0 {
 			clock-frequency = <0>;
@@ -16,7 +16,7 @@
 			i-cache-sets = <128>;
 			i-cache-size = <16384>;
 			next-level-cache = <&L12>;
-			reg = <0 0>;
+			reg = <0>;
 			riscv,isa = "rv64imac";
 			sifive,dtim = <&L5>;
 			sifive,itim = <&L4>;


### PR DESCRIPTION
Add the macros for PLIC driver using to calculate the offset of hart context id. Here also create a new function that PLIC driver can get the own machine mode context id to claim and complete own region.