### PR TITLE
remove autoreconf from autoconf_wrapper script

### DIFF
--- a/scripts/autoconf_wrapper
+++ b/scripts/autoconf_wrapper
@@ -17,7 +17,6 @@ case $i in
 esac
 done
 
-autoreconf -i
 ./configure ${CONFIGURE_ARGS} --prefix=
 make
 make DESTDIR=$(pwd)/${INSTALL_DIR} install


### PR DESCRIPTION
Don't run `autoreconf -i` since the output of autotools is already checked in.