### PR TITLE
Properly offset the location counter to allocate multiple stacks

### DIFF
--- a/linker_script/sections/uninit_group.c++
+++ b/linker_script/sections/uninit_group.c++
@@ -40,10 +40,10 @@ UninitGroup::UninitGroup(const fdt &dtb, Memory logical_memory, Phdr logical_hea
   stack.output_name = "stack";
 
   stack.add_command("PROVIDE(metal_segment_stack_begin = .);");
-  stack.add_command(". = __stack_size;");
+  stack.add_command(". += __stack_size;");
   stack.add_command("PROVIDE( _sp = . );");
   for (int i = 0; i < (num_harts - 1); i++) {
-    stack.add_command(". = __stack_size;");
+    stack.add_command(". += __stack_size;");
   }
   stack.add_command("PROVIDE(metal_segment_stack_end = .);");
 


### PR DESCRIPTION
Increment instead of assign to allocate space for multiple stacks.