### PR TITLE
[v19.08] Get first unnamed reg from a memory node

### DIFF
--- a/linker_script/freedom-ldscript-generator.c++
+++ b/linker_script/freedom-ldscript-generator.c++
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <list>
 #include <regex>
+#include <tuple>
 
 #include <fdt.h++>
 
@@ -122,14 +123,12 @@ int main (int argc, char* argv[])
         m.size = ranges.front().size;
       }
     } else {
-      n.maybe_tuple(
-        "reg",
-        tuple_t<target_addr, target_size>(),
-        [&]() {},
-        [&](target_addr b, target_size s) {
-          m.base = b;
-          m.size = s;
-        });
+      auto regs = n.get_fields<std::tuple<target_addr, target_size>>("reg");
+
+      if (!regs.empty()) {
+        m.base = std::get<0>(regs.front());
+        m.size = std::get<1>(regs.front());
+      }
     }
   };
 


### PR DESCRIPTION
Backport memory range selection criteria to `v201908-branch` in case we want to make this selection criteria official for a point release. **DNM** until that decision is made.

Given a memory node with two address ranges listed as unnamed `reg`:
```
memory@70000000 {
    device_type = "memory";
    reg = <0x70000000 0x800000 0x80000000 0x80000000>;
}; 
```

This patch picks the first of the two ranges (`0x70000000-0x70800000`) instead of the last (`0x80000000-0xFFFFFFFF`).