### PR TITLE
Support maximal-heap size option

### DIFF
--- a/linker_script/sections/uninit_group.c++
+++ b/linker_script/sections/uninit_group.c++
@@ -52,7 +52,10 @@ UninitGroup::UninitGroup(const fdt &dtb, Memory logical_memory,
   heap.output_name = "heap";
 
   heap.add_command("PROVIDE( metal_segment_heap_target_start = . );");
-  heap.add_command(". = __heap_size;");
+  heap.add_command(". = DEFINED(__heap_max) ? LENGTH(" + virtual_memory.name +
+                   ") - ( . - ORIGIN(" + virtual_memory.name +
+                   ") "
+                   ") : __heap_size;");
   heap.add_command("PROVIDE( metal_segment_heap_target_end = . );");
   heap.add_command("PROVIDE( _heap_end = . );");
 


### PR DESCRIPTION
let linker script support maximal-heap-size which use rest of ram as heap.
This is an optional functionality only work when "-Xlinker --defsym=__heap_max=1" is passed to linker.
if __heap_size and __heap_max are defined at the same time, __heap_max will overwrite __heap_size.
please help to review & comment. thx.