### PR TITLE
Parameterizing the generated openocd.cfg file

### DIFF
--- a/freedom-openocdcfg-generator.c++
+++ b/freedom-openocdcfg-generator.c++
@@ -424,39 +424,43 @@ static void write_config_file(fstream &os, std::string board,
 
     if (protocol == "cjtag") {
       os << "    set protocol 1" << std::endl;
-    }
-    else if (protocol == "jtagtunnel") {
+    } else if (protocol == "jtagtunnel") {
       os << "    set protocol 2" << std::endl;
-    }
-    else {
+    } else {
       os << "    set protocol 0" << std::endl;
     }
     os << "}" << std::endl << std::endl;
 
-    os << "# Bring in the correct configuration script for the specified" << std::endl;
+    os << "# Bring in the correct configuration script for the specified"
+       << std::endl;
     os << "# protocol" << std::endl;
     os << "switch -regexp $protocol {" << std::endl;
     os << "    (0|jtag) {" << std::endl;
     os << "        echo \"Using JTAG\"" << std::endl;
-    os << "        source [find interface/ftdi/olimex-arm-usb-tiny-h.cfg]" << std::endl;
+    os << "        source [find interface/ftdi/olimex-arm-usb-tiny-h.cfg]"
+       << std::endl;
     os << "        set chain_length 5" << std::endl;
     os << "    }" << std::endl;
     os << "    (1|cjtag) {" << std::endl;
     os << "        echo \"Using cJTAG\"" << std::endl;
-    os << "        source [find interface/ftdi/olimex-arm-jtag-cjtag.cfg]" << std::endl;
+    os << "        source [find interface/ftdi/olimex-arm-jtag-cjtag.cfg]"
+       << std::endl;
     os << "    }" << std::endl;
     os << "    (2|tunnel) {" << std::endl;
     os << "        echo \"Using JTAG tunnel\"" << std::endl;
-    os << "        source [find interface/ftdi/arty-onboard-ftdi.cfg]" << std::endl;
+    os << "        source [find interface/ftdi/arty-onboard-ftdi.cfg]"
+       << std::endl;
     os << "        set chain_length 6" << std::endl;
     os << "    }" << std::endl;
     os << "    default {" << std::endl;
-    os << "        error \"Unknown protocol specified: $protocol\"" << std::endl;
+    os << "        error \"Unknown protocol specified: $protocol\""
+       << std::endl;
     os << "    }" << std::endl;
     os << "}" << std::endl << std::endl;
   }
   os << "set _CHIPNAME riscv" << std::endl;
-  os << "jtag newtap $_CHIPNAME cpu -irlen $chain_length" << std::endl << std::endl;
+  os << "jtag newtap $_CHIPNAME cpu -irlen $chain_length" << std::endl
+     << std::endl;
 
   os << "set _TARGETNAME $_CHIPNAME.cpu" << std::endl;
   os << "target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME"
@@ -511,7 +515,9 @@ static void write_config_file(fstream &os, std::string board,
 
   os << "init" << std::endl;
 
-  os << "# If required, the authdata_write command must be added immediately after" << std::endl;
+  os << "# If required, the authdata_write command must be added immediately "
+        "after"
+     << std::endl;
   os << "# the 'init' command.  Use: " << std::endl;
   os << "# riscv authdata_write ????????" << std::endl;
   os << "if { [info exists authkey] } {" << std::endl;
@@ -531,16 +537,16 @@ static void write_config_file(fstream &os, std::string board,
 }
 
 static void show_usage(string name) {
-  std::cerr
-      << "Usage: " << name << " <option(s)>\n"
-      << "Options:\n"
-      << "\t-h,--help\t\t\tShow this help message\n"
-      << "\t-p,--protocol <jtag | cjtag | tunnel>\tSpecify protocol, defaults to jtag\n"
-      << "\t-b,--board <eg. arty | hifive1>\tSpecify board type\n"
-      << "\t-d,--dtb <eg. xxx.dtb>\t\tSpecify fullpath to the DTB file\n"
-      << "\t-o,--output <eg. openocd.cfg>\tGenerate openocd config file\n"
-      << "\t-s,--show \t\t\tShow openocd config file on std-output\n"
-      << endl;
+  std::cerr << "Usage: " << name << " <option(s)>\n"
+            << "Options:\n"
+            << "\t-h,--help\t\t\tShow this help message\n"
+            << "\t-p,--protocol <jtag | cjtag | tunnel>\tSpecify protocol, "
+               "defaults to jtag\n"
+            << "\t-b,--board <eg. arty | hifive1>\tSpecify board type\n"
+            << "\t-d,--dtb <eg. xxx.dtb>\t\tSpecify fullpath to the DTB file\n"
+            << "\t-o,--output <eg. openocd.cfg>\tGenerate openocd config file\n"
+            << "\t-s,--show \t\t\tShow openocd config file on std-output\n"
+            << endl;
 }
 
 int main(int argc, char *argv[]) {
@@ -585,13 +591,15 @@ int main(int argc, char *argv[]) {
         if (i + 1 < argc) {
           protocol = argv[++i];
           if ((protocol != "jtag") && (protocol != "cjtag")) {
-            std::cerr << "Possible options for --protocol are <jtag | cjtag | tunnel>."
+            std::cerr << "Possible options for --protocol are <jtag | cjtag | "
+                         "tunnel>."
                       << std::endl;
             show_usage(argv[0]);
             return 1;
           }
         } else {
-          std::cerr << "--protocol option requires an argument <jtag | cjtag | tunnel."
+          std::cerr << "--protocol option requires an argument <jtag | cjtag | "
+                       "tunnel."
                     << std::endl;
           show_usage(argv[0]);
           return 1;
@@ -605,7 +613,8 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  if ((board.find("hifive") != string::npos) && ((protocol == "cjtag") || (protocol == "tunnel"))) {
+  if ((board.find("hifive") != string::npos) &&
+      ((protocol == "cjtag") || (protocol == "tunnel"))) {
     std::cerr << "HiFive boards are not capable of using cJTAG." << std::endl;
     return 1;
   }


### PR DESCRIPTION
Added the ability specify the protocol and authkey to the generated openocd.cfg file, and added support for the Digilent jtag tunnel (bscan).  This should allow us to provide a single openocd.cfg file supporting all protocols (and avoid future proliferation of the generated config files to handle various configuration combinations that will arise).  

[Nate, it is up to you if you want to continue to provide both jtag and cjtag variants for CLI usage (and potentially a tunnel variant when that rolls out).  Freedom Studio will use the single default openocd.cfg file for all combinations.  This branch/PR eclipses the auth_comments branch/PR.  That branch can be deleted without merging.]

**Protocol Support** 
Defaults to the protocol specified by the `-protocol` switch to the script generator executable, which defaults to jtag if not specified).  Default behavior of the PR should be identical to the original and work with previous version of FS.

Use the CLI set the protocol:

`-c "set protocol ((jtag|0) | (cjtag|1) | (tunnel|2))"`

Freedom Studio has a UI for selecting the protocol (and FS will set it automatically once we have the data available in the IP delivery metadata).

![image](https://user-images.githubusercontent.com/43148204/67967496-ea9e9780-fbc2-11e9-9702-1720b2a8bfb5.png)

**Secure DM Support**
Use the CLI to specify a DM unlock key:

`-c "set authkey xxxxxxxx"`

Freedom Studio has a UI for specifying the authkey (see screenshot above).

I've tested this PR using Freedom Studio's features to rebuild FDT in an IP delivery and regenerate BSPs.  Tested all three protocols and secure dm.

All testing was done on Windows (using mingw to build FDT).
