### PR TITLE
Fix maximal-heap size  cause relocation error

### DIFF
--- a/linker_script/sections/uninit_group.c++
+++ b/linker_script/sections/uninit_group.c++
@@ -52,9 +52,10 @@ UninitGroup::UninitGroup(const fdt &dtb, Memory logical_memory,
   heap.output_name = "heap";
 
   heap.add_command("PROVIDE( metal_segment_heap_target_start = . );");
-  heap.add_command(". = DEFINED(__heap_max) ? LENGTH(" + virtual_memory.name +
-                   ") - ( . - ORIGIN(" + virtual_memory.name +
-                   ") "
+  heap.add_command(". = DEFINED(__heap_max) ? MIN( LENGTH(" +
+                   virtual_memory.name + ") - ( . - ORIGIN(" +
+                   virtual_memory.name +
+                   ")) , 0x10000000"
                    ") : __heap_size;");
   heap.add_command("PROVIDE( metal_segment_heap_target_end = . );");
   heap.add_command("PROVIDE( _heap_end = . );");


### PR DESCRIPTION
Origin maximal-heap size will cause sbrk function relocation truncated to fit error 
when linker script has huge ram.
we add a heap_size upper bound to fix this. 
This modification only affect when __heap_max is defined.

please help to review & comment.
Thx