### PR TITLE
sifive,wdt0 is another compatible string for sifive,wdog0

### DIFF
--- a/bare_header/device.c++
+++ b/bare_header/device.c++
@@ -44,7 +44,7 @@ void Device::emit_comment(const node &n) {
 }
 
 string Device::def_handle(const node &n) {
-  string name = compat_string;
+  string name = n.get_fields<string>("compatible")[0];
   string instance = n.instance();
 
   std::transform(name.begin(), name.end(), name.begin(),
@@ -60,7 +60,7 @@ string Device::def_handle(const node &n) {
 }
 
 string Device::def_handle_index(const node &n) {
-  string name = compat_string;
+  string name = n.get_fields<string>("compatible")[0];
   string instance = std::to_string(get_index(n));
 
   std::transform(name.begin(), name.end(), name.begin(),
@@ -144,8 +144,9 @@ void Device::emit_size(const node &n) {
   }
 }
 
-void Device::emit_compat() {
-  string compat = compat_string;
+void Device::emit_compat() { emit_compat(compat_string); }
+
+void Device::emit_compat(string compat) {
   std::transform(compat.begin(), compat.end(), compat.begin(),
                  [](unsigned char c) -> char {
                    if (c == ',' || c == '-') {
@@ -156,8 +157,7 @@ void Device::emit_compat() {
   os << "#define METAL_" << compat << std::endl;
 }
 
-void Device::emit_offset(string offset_name, uint32_t offset) {
-  string name = compat_string;
+void Device::emit_offset(string name, string offset_name, uint32_t offset) {
   std::transform(name.begin(), name.end(), name.begin(),
                  [](unsigned char c) -> char {
                    if (c == ',' || c == '-') {
@@ -168,6 +168,10 @@ void Device::emit_offset(string offset_name, uint32_t offset) {
 
   os << "#define METAL_" << name << "_" << offset_name << " " << offset << "UL"
      << std::endl;
+}
+
+void Device::emit_offset(string offset_name, uint32_t offset) {
+  emit_offset(compat_string, offset_name, offset);
 }
 
 void Device::emit_property_u32(const node &n, string property_name,

--- a/bare_header/device.h
+++ b/bare_header/device.h
@@ -44,7 +44,9 @@ public:
   void emit_size(const node &n);
 
   void emit_compat();
+  void emit_compat(string compat);
 
+  void emit_offset(string name, string offset_name, uint32_t offset);
   void emit_offset(string offset_name, uint32_t offset);
 
   void emit_property_u32(const node &n, string property_name, uint32_t value);

--- a/bare_header/sifive_rtc0.h
+++ b/bare_header/sifive_rtc0.h
@@ -11,14 +11,10 @@
 class sifive_rtc0 : public Device {
 public:
   sifive_rtc0(std::ostream &os, const fdt &dtb)
-      : Device(os, dtb, "sifive,rtc0") {}
-
-  int get_index(const node &n) override {
-    return Device::get_index(n, "sifive,(rtc|aon0)");
-  }
+      : Device(os, dtb, "sifive,(rtc|aon)0") {}
 
   void emit_defines() override {
-    dtb.match(std::regex("sifive,(rtc0|aon0)"), [&](node n) {
+    dtb.match(std::regex(compat_string), [&](node n) {
       emit_comment(n);
 
       emit_base(n);
@@ -29,14 +25,14 @@ public:
   }
 
   void emit_offsets() override {
-    if (dtb.match(std::regex("sifive,(rtc0|aon0)"), [](const node n) {}) != 0) {
-      emit_compat();
+    if (dtb.match(std::regex(compat_string), [](const node n) {}) != 0) {
+      emit_compat("sifive,rtc0");
 
-      emit_offset("RTCCFG", 0x40);
-      emit_offset("RTCCOUNTLO", 0x48);
-      emit_offset("RTCCOUNTHI", 0x4C);
-      emit_offset("RTCS", 0x50);
-      emit_offset("RTCCMP0", 0x60);
+      emit_offset("sifive,rtc0", "RTCCFG", 0x40);
+      emit_offset("sifive,rtc0", "RTCCOUNTLO", 0x48);
+      emit_offset("sifive,rtc0", "RTCCOUNTHI", 0x4C);
+      emit_offset("sifive,rtc0", "RTCS", 0x50);
+      emit_offset("sifive,rtc0", "RTCCMP0", 0x60);
 
       os << std::endl;
     }

--- a/bare_header/sifive_wdog0.h
+++ b/bare_header/sifive_wdog0.h
@@ -12,14 +12,10 @@
 class sifive_wdog0 : public Device {
 public:
   sifive_wdog0(std::ostream &os, const fdt &dtb)
-      : Device(os, dtb, "sifive,wdog0") {}
-
-  int get_index(const node &n) override {
-    return Device::get_index(n, "sifive,(wdog0|aon0)");
-  }
+      : Device(os, dtb, "sifive,(wdog|wdt|aon)0") {}
 
   void emit_defines() override {
-    dtb.match(std::regex("sifive,(wdog0|aon0)"), [&](node n) {
+    dtb.match(std::regex(compat_string), [&](node n) {
       emit_comment(n);
 
       emit_base(n);
@@ -30,19 +26,18 @@ public:
   }
 
   void emit_offsets() override {
-    if (dtb.match(std::regex("sifive,(wdog0|aon0)"), [](const node n) {}) !=
-        0) {
-      emit_compat();
+    if (dtb.match(std::regex(compat_string), [](const node n) {}) != 0) {
+      emit_compat("sifive,wdog0");
 
-      emit_offset("MAGIC_KEY", 0x51f15e);
-      emit_offset("MAGIC_FOOD", 0xd09F00d);
+      emit_offset("sifive,wdog0", "MAGIC_KEY", 0x51f15e);
+      emit_offset("sifive,wdog0", "MAGIC_FOOD", 0xd09F00d);
 
-      emit_offset("WDOGCFG", 0x0);
-      emit_offset("WDOGCOUNT", 0x8);
-      emit_offset("WDOGS", 0x10);
-      emit_offset("WDOGFEED", 0x18);
-      emit_offset("WDOGKEY", 0x1c);
-      emit_offset("WDOGCMP", 0x20);
+      emit_offset("sifive,wdog0", "WDOGCFG", 0x0);
+      emit_offset("sifive,wdog0", "WDOGCOUNT", 0x8);
+      emit_offset("sifive,wdog0", "WDOGS", 0x10);
+      emit_offset("sifive,wdog0", "WDOGFEED", 0x18);
+      emit_offset("sifive,wdog0", "WDOGKEY", 0x1c);
+      emit_offset("sifive,wdog0", "WDOGCMP", 0x20);
 
       os << std::endl;
     }

--- a/metal_header/sifive_wdog0.c++
+++ b/metal_header/sifive_wdog0.c++
@@ -6,7 +6,7 @@
 #include <regex>
 
 sifive_wdog0::sifive_wdog0(std::ostream &os, const fdt &dtb)
-    : Device(os, dtb, "sifive,(wdog0|aon0)") {
+    : Device(os, dtb, "sifive,(wdog0|aon0|wdt0)") {
   num_wdogs = 0;
   dtb.match(std::regex(compat_string), [&](node n) { num_wdogs += 1; });
 }


### PR DESCRIPTION
Includes some changes to allow `Device::emit_compat()` and `Device::emit_offset()` in the bare_header generator to accept a compatible string override.