### PR TITLE
HCA define generation into metal-platform.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -117,6 +117,7 @@ freedom_bare_header_generator_SOURCES = \
 	bare_header/sifive_uart0.h \
 	bare_header/sifive_wdog0.h \
 	bare_header/ucb_htif0.h \
+	bare_header/sifive_hca_0_5_0.h \
 	ranges.c++ \
 	ranges.h
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -658,6 +658,7 @@ freedom_bare_header_generator_SOURCES = \
 	bare_header/sifive_uart0.h \
 	bare_header/sifive_wdog0.h \
 	bare_header/ucb_htif0.h \
+	bare_header/sifive_hca_0_5_0.h \
 	ranges.c++ \
 	ranges.h
 

--- a/bare_header/device.c++
+++ b/bare_header/device.c++
@@ -46,20 +46,20 @@ void Device::emit_comment(const node &n) {
 string Device::def_handle(const node &n) {
   string name = n.get_fields<string>("compatible")[0];
 
-  return def_handle(name,n);
+  return def_handle(name, n);
 }
 
 string Device::def_handle(std::string name, const node &n) {
   string instance = n.instance();
 
   std::transform(name.begin(), name.end(), name.begin(),
-                [](unsigned char c) -> char {
-                  if (c == ',' || c == '-' ) {
-                    return '_';
-                  }
-                  return toupper(c);
-                });
-  
+                 [](unsigned char c) -> char {
+                   if (c == ',' || c == '-') {
+                     return '_';
+                   }
+                   return toupper(c);
+                 });
+
   std::transform(instance.begin(), instance.end(), instance.begin(), toupper);
 
   return "METAL_" + name + "_" + instance;
@@ -67,7 +67,7 @@ string Device::def_handle(std::string name, const node &n) {
 
 string Device::def_handle_index(const node &n) {
   string name = n.get_fields<string>("compatible")[0];
-  return def_handle_index(name ,n);
+  return def_handle_index(name, n);
 }
 
 string Device::def_handle_index(std::string name, const node &n) {
@@ -75,7 +75,7 @@ string Device::def_handle_index(std::string name, const node &n) {
 
   std::transform(name.begin(), name.end(), name.begin(),
                  [](unsigned char c) -> char {
-                   if (c == ',' || c == '-' ) {
+                   if (c == ',' || c == '-') {
                      return '_';
                    }
                    return toupper(c);
@@ -142,14 +142,15 @@ void Device::emit_base(const node &n) {
   }
 }
 
-void Device::emit_base(std::string compat,const node &n) {
-  os << "#define " << def_handle(compat, n) << "_" METAL_BASE_ADDRESS_LABEL << " "
-     << base_address(n) << "UL" << std::endl;
+void Device::emit_base(std::string compat, const node &n) {
+  os << "#define " << def_handle(compat, n) << "_" METAL_BASE_ADDRESS_LABEL
+     << " " << base_address(n) << "UL" << std::endl;
 
   // If the address is very small, it already is an index.
   if (n.instance().length() > 2) {
-    os << "#define " << def_handle_index(compat, n) << "_" METAL_BASE_ADDRESS_LABEL
-       << " " << base_address(n) << "UL" << std::endl;
+    os << "#define " << def_handle_index(compat, n)
+       << "_" METAL_BASE_ADDRESS_LABEL << " " << base_address(n) << "UL"
+       << std::endl;
   }
 }
 
@@ -167,13 +168,13 @@ void Device::emit_size(const node &n) {
 }
 
 void Device::emit_size(std::string compat, const node &n) {
-  os << "#define " << def_handle(compat, n) << "_" << METAL_SIZE_LABEL << " " << size(n)
-     << "UL" << std::endl;
+  os << "#define " << def_handle(compat, n) << "_" << METAL_SIZE_LABEL << " "
+     << size(n) << "UL" << std::endl;
 
   // If the address is very small, it already is an index.
   if (n.instance().length() > 2) {
-    os << "#define " << def_handle_index(compat, n) << "_" << METAL_SIZE_LABEL << " "
-       << size(n) << "UL" << std::endl;
+    os << "#define " << def_handle_index(compat, n) << "_" << METAL_SIZE_LABEL
+       << " " << size(n) << "UL" << std::endl;
   }
 }
 

--- a/bare_header/device.c++
+++ b/bare_header/device.c++
@@ -45,15 +45,21 @@ void Device::emit_comment(const node &n) {
 
 string Device::def_handle(const node &n) {
   string name = n.get_fields<string>("compatible")[0];
+
+  return def_handle(name,n);
+}
+
+string Device::def_handle(std::string name, const node &n) {
   string instance = n.instance();
 
   std::transform(name.begin(), name.end(), name.begin(),
-                 [](unsigned char c) -> char {
-                   if (c == ',' || c == '-') {
-                     return '_';
-                   }
-                   return toupper(c);
-                 });
+                [](unsigned char c) -> char {
+                  if (c == ',' || c == '-' ) {
+                    return '_';
+                  }
+                  return toupper(c);
+                });
+  
   std::transform(instance.begin(), instance.end(), instance.begin(), toupper);
 
   return "METAL_" + name + "_" + instance;
@@ -61,11 +67,15 @@ string Device::def_handle(const node &n) {
 
 string Device::def_handle_index(const node &n) {
   string name = n.get_fields<string>("compatible")[0];
+  return def_handle_index(name ,n);
+}
+
+string Device::def_handle_index(std::string name, const node &n) {
   string instance = std::to_string(get_index(n));
 
   std::transform(name.begin(), name.end(), name.begin(),
                  [](unsigned char c) -> char {
-                   if (c == ',' || c == '-') {
+                   if (c == ',' || c == '-' ) {
                      return '_';
                    }
                    return toupper(c);
@@ -132,6 +142,17 @@ void Device::emit_base(const node &n) {
   }
 }
 
+void Device::emit_base(std::string compat,const node &n) {
+  os << "#define " << def_handle(compat, n) << "_" METAL_BASE_ADDRESS_LABEL << " "
+     << base_address(n) << "UL" << std::endl;
+
+  // If the address is very small, it already is an index.
+  if (n.instance().length() > 2) {
+    os << "#define " << def_handle_index(compat, n) << "_" METAL_BASE_ADDRESS_LABEL
+       << " " << base_address(n) << "UL" << std::endl;
+  }
+}
+
 uint64_t Device::size(const node &n) { return extract_mem_map(n).size; }
 
 void Device::emit_size(const node &n) {
@@ -145,12 +166,23 @@ void Device::emit_size(const node &n) {
   }
 }
 
+void Device::emit_size(std::string compat, const node &n) {
+  os << "#define " << def_handle(compat, n) << "_" << METAL_SIZE_LABEL << " " << size(n)
+     << "UL" << std::endl;
+
+  // If the address is very small, it already is an index.
+  if (n.instance().length() > 2) {
+    os << "#define " << def_handle_index(compat, n) << "_" << METAL_SIZE_LABEL << " "
+       << size(n) << "UL" << std::endl;
+  }
+}
+
 void Device::emit_compat() { emit_compat(compat_string); }
 
 void Device::emit_compat(string compat) {
   std::transform(compat.begin(), compat.end(), compat.begin(),
                  [](unsigned char c) -> char {
-                   if (c == ',' || c == '-') {
+                   if (c == ',' || c == '-' || c == '.') {
                      return '_';
                    }
                    return toupper(c);
@@ -161,7 +193,7 @@ void Device::emit_compat(string compat) {
 void Device::emit_offset(string name, string offset_name, uint32_t offset) {
   std::transform(name.begin(), name.end(), name.begin(),
                  [](unsigned char c) -> char {
-                   if (c == ',' || c == '-') {
+                   if (c == ',' || c == '-' || c == '.') {
                      return '_';
                    }
                    return toupper(c);

--- a/bare_header/device.h
+++ b/bare_header/device.h
@@ -36,12 +36,16 @@ public:
   void emit_comment(const node &n);
 
   string def_handle(const node &n);
+  string def_handle(string name, const node &n);
   string def_handle_index(const node &n);
+  string def_handle_index(string name, const node &n);
   virtual uint64_t base_address(const node &n);
   void emit_base(const node &n);
+  void emit_base(string name, const node &n);
 
   virtual uint64_t size(const node &n);
   void emit_size(const node &n);
+  void emit_size(string name, const node &n);
 
   void emit_compat();
   void emit_compat(string compat);

--- a/bare_header/freedom-bare_header-generator.c++
+++ b/bare_header/freedom-bare_header-generator.c++
@@ -39,6 +39,7 @@
 #include "bare_header/sifive_gpio_buttons.h"
 #include "bare_header/sifive_gpio_leds.h"
 #include "bare_header/sifive_gpio_switches.h"
+#include "bare_header/sifive_hca_0_5_0.h"
 #include "bare_header/sifive_i2c0.h"
 #include "bare_header/sifive_local_external_interrupts0.h"
 #include "bare_header/sifive_pwm0.h"
@@ -168,6 +169,7 @@ static void write_config_file(const fdt &dtb, fstream &os, std::string cfg_file,
   devices.push_back(new sifive_uart0(os, dtb));
   devices.push_back(new sifive_wdog0(os, dtb));
   devices.push_back(new ucb_htif0(os, dtb));
+  devices.push_back(new sifive_hca_0_5_0(os, dtb));
 
   for (auto it = devices.begin(); it != devices.end(); it++) {
     (*it)->emit_defines();

--- a/bare_header/sifive_hca_0_5_0.h
+++ b/bare_header/sifive_hca_0_5_0.h
@@ -1,0 +1,62 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __BARE_HEADER_SIFIVE_HCA_0_5_0__H
+#define __BARE_HEADER_SIFIVE_HCA_0_5_0__H
+
+#include "bare_header/device.h"
+
+#include <regex>
+#include <set>
+
+class sifive_hca_0_5_0 : public Device {
+public:
+  sifive_hca_0_5_0(std::ostream &os, const fdt &dtb)
+      : Device(os, dtb, "sifive,hca-0.5.0") {}
+
+  void emit_defines() override {
+    dtb.match(std::regex(compat_string), [&](node n) {
+      emit_comment(n);
+
+      emit_base("sifive,hca", n);
+      emit_size("sifive,hca", n);
+
+      os << std::endl;
+    });
+  }
+
+  void emit_offsets() override {
+    if (dtb.match(std::regex(compat_string), [](const node n) {}) != 0) {
+      emit_compat();
+
+      /* Add offsets here */
+      emit_offset("sifive,hca", "VERSION", 0x000500);
+      emit_offset("sifive,hca", "CR", 0x0);
+      emit_offset("sifive,hca", "AES_CR", 0x10);
+      emit_offset("sifive,hca", "AES_ALEN", 0x20);
+      emit_offset("sifive,hca", "AES_PDLEN", 0x28);
+      emit_offset("sifive,hca", "AES_KEY", 0x30);
+      emit_offset("sifive,hca", "AES_INITV", 0x50);
+      emit_offset("sifive,hca", "FIFO_IN", 0x70);
+      emit_offset("sifive,hca", "AES_OUT", 0x80);
+      emit_offset("sifive,hca", "AES_AUTH", 0x90);
+      emit_offset("sifive,hca", "HASH", 0xA0);
+      emit_offset("sifive,hca", "TRNG_CR", 0xE0);
+      emit_offset("sifive,hca", "TRNG_SR", 0xE4);
+      emit_offset("sifive,hca", "TRNG_DATA", 0xE8);
+      emit_offset("sifive,hca", "TRNG_TRIM", 0xEC);
+      emit_offset("sifive,hca", "DMA_CR", 0x110);
+      emit_offset("sifive,hca", "DMA_LEN", 0x114);
+      emit_offset("sifive,hca", "DMA_SRC", 0x118);
+      emit_offset("sifive,hca", "DMA_DEST", 0x11C);
+      emit_offset("sifive,hca", "HCA_REV", 0x200);
+      emit_offset("sifive,hca", "AES_REV", 0x204);
+      emit_offset("sifive,hca", "SHA_REV", 0x208);
+      emit_offset("sifive,hca", "TRNG_REV", 0x20C);
+
+      os << std::endl;
+    }
+  }
+};
+
+#endif


### PR DESCRIPTION
the device.c++ have been modyfied in order to allow to pass a string into the function emit_base an emit_size (in order to not have the version of the HCA into the define).
here the result of the generation:

/* From hca@a000 */
#define METAL_SIFIVE_HCA_A000_BASE_ADDRESS 40960UL
#define METAL_SIFIVE_HCA_0_BASE_ADDRESS 40960UL
#define METAL_SIFIVE_HCA_A000_SIZE 4096UL
#define METAL_SIFIVE_HCA_0_SIZE 4096UL

#define METAL_SIFIVE_HCA_0_5_0
#define METAL_SIFIVE_HCA_VERSION 1280UL
#define METAL_SIFIVE_HCA_CR 0UL
#define METAL_SIFIVE_HCA_AES_CR 16UL
...