### PR TITLE
Remove handles for local external interrupts

### DIFF
--- a/metal_header/sifive_local_external_interrupts0.c++
+++ b/metal_header/sifive_local_external_interrupts0.c++
@@ -180,9 +180,3 @@ void sifive_local_external_interrupts0::define_structs() {
     emit_struct_end();
   });
 }
-
-void sifive_local_external_interrupts0::create_handles() {
-  dtb.match(std::regex(compat_string), [&](node n) {
-    emit_def_handle("__METAL_DT_SIFIVE_LOCAL_EXINTR0_HANDLE", n, ".irc");
-  });
-}

--- a/metal_header/sifive_local_external_interrupts0.h
+++ b/metal_header/sifive_local_external_interrupts0.h
@@ -20,7 +20,6 @@ public:
   void define_inlines();
   void declare_structs();
   void define_structs();
-  void create_handles();
 };
 
 #endif


### PR DESCRIPTION
The local external interrupt handles are never used, and when a target has multiple local external interrupt nodes, this code generates multiple identical macros which causes compile warnings:

```
./metal/machine.h:1335: warning: "__METAL_DT_SIFIVE_LOCAL_EXINTR0_HANDLE" redefined
 #define __METAL_DT_SIFIVE_LOCAL_EXINTR0_HANDLE (&__metal_dt_local_external_interrupts_1.irc)

./metal/machine.h:1330: note: this is the location of the previous definition
 #define __METAL_DT_SIFIVE_LOCAL_EXINTR0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
```

Since these are private, we can safely remove this without breaking API.