### PR TITLE
Define interrupt parent for all UART devices

### DIFF
--- a/metal_header/sifive_uart0.c++
+++ b/metal_header/sifive_uart0.c++
@@ -102,11 +102,9 @@ void sifive_uart0::define_inlines() {
     std::string int_parent_value = "NULL";
     n.maybe_tuple("interrupt-parent", tuple_t<node>(), [&]() {},
                   [&](node m) {
-                    if (count == 0) {
-                      int_parent_value =
-                          "(struct metal_interrupt *)&__metal_dt_" +
-                          m.handle() + ".controller";
-                    }
+                    int_parent_value =
+                        "(struct metal_interrupt *)&__metal_dt_" + m.handle() +
+                        ".controller";
                   });
     std::string int_line_value = "0";
     n.maybe_tuple(


### PR DESCRIPTION
Other device drivers appear to declare interrupt parents for all
instances of a given type. Change the sifive_uart0 header generation
to emit definitions for all devices instead of just the first one.

	https://sifive.atlassian.net/browse/ST-76

Signed-off-by: Keith Packard <keithp@keithp.com>