### PR TITLE
Chaneg AON to use control instead of mem for reg-names

### DIFF
--- a/bare_header/sifive_aon0.h
+++ b/bare_header/sifive_aon0.h
@@ -16,7 +16,7 @@ public:
   uint64_t base_address(const node &n) {
     uint64_t b;
 
-    n.named_tuples("reg-names", "reg", "mem",
+    n.named_tuples("reg-names", "reg", "control",
                    tuple_t<target_addr, target_size>(),
                    [&](target_addr base, target_size size) { b = base; });
 
@@ -26,7 +26,7 @@ public:
   uint64_t size(const node &n) {
     uint64_t s;
 
-    n.named_tuples("reg-names", "reg", "mem",
+    n.named_tuples("reg-names", "reg", "control",
                    tuple_t<target_addr, target_size>(),
                    [&](target_addr base, target_size size) { s = size; });
 

--- a/tests/qemu-sifive-e31/core.dts
+++ b/tests/qemu-sifive-e31/core.dts
@@ -86,7 +86,7 @@
                 aon: aon@10000000 {
                         compatible = "sifive,aon0";
                         reg = <0x10000000 0x8000>;
-                        reg-names = "mem";
+                        reg-names = "control";
                 };
                 prci: prci@10008000 {
                         compatible = "sifive,fe310-g000,prci";

--- a/tests/qemu-sifive-s51/core.dts
+++ b/tests/qemu-sifive-s51/core.dts
@@ -89,7 +89,7 @@
                 aon: aon@10000000 {
                         compatible = "sifive,aon0";
                         reg = <0x10000000 0x8000>;
-                        reg-names = "mem";
+                        reg-names = "control";
                 };
 
                 prci: prci@10008000 {

--- a/tests/sifive-hifive1-revb/core.dts
+++ b/tests/sifive-hifive1-revb/core.dts
@@ -123,7 +123,7 @@
                 aon: aon@10000000 {
                         compatible = "sifive,aon0";
                         reg = <0x10000000 0x8000>;
-                        reg-names = "mem";
+                        reg-names = "control";
                         interrupt-parent = <&plic>;
                         interrupts = <1 2>;
                         clocks = <&lfclk>;

--- a/tests/sifive-hifive1/core.dts
+++ b/tests/sifive-hifive1/core.dts
@@ -85,7 +85,7 @@
                 aon: aon@10000000 {
                         compatible = "sifive,aon0";
                         reg = <0x10000000 0x8000>;
-                        reg-names = "mem";
+                        reg-names = "control";
                 };
 
                 prci: prci@10008000 {


### PR DESCRIPTION
Part of addressing re-definition warnings when building bsp and failed tests for https://github.com/sifive/freedom-e-sdk/pull/462, and part of addressing https://github.com/sifive/freedom-e-sdk/issues/461

`make check-TESTS` also passes all 82 tests.