### PR TITLE
Add wake target for installing Devicetree Tools sources

### DIFF
--- a/.github/workflows/wake.yml
+++ b/.github/workflows/wake.yml
@@ -1,0 +1,39 @@
+name: wake-api-test
+
+on:
+  push:
+    path-ignore:
+      - '**.md'
+      - 'LICENSE'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      # $WIT_WORKSPACE path is relative to $GITHUB_WORKSPACE
+      WIT_WORKSPACE: wit-workspace
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: wit-packages/freedom-devicetree-tools
+
+      - name: 'Init Wit Workspace'
+        uses: sifive/wit/actions/wit@v0.12.0
+        with:
+          command: init
+          arguments: |
+            ${{ env.WIT_WORKSPACE }}
+            -a ./wit-packages/freedom-devicetree-tools
+            -a git@github.com:sifive/environment-blockci-sifive.git::0.3.0
+          force_github_https: true
+
+      - name: 'Run generator install test'
+        run: |
+          set -euo pipefail
+          docker run \
+            --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
+            --workdir="/mnt/workspace" \
+            --rm \
+            sifive/environment-blockci:0.3.0 \
+            freedom-devicetree-tools/tests/test-wake-install.sh

--- a/build.wake
+++ b/build.wake
@@ -88,3 +88,37 @@ global def runFreedomBareHeaderGenerator options =
     Nil
   def inputs = mkdir "{outputFile}/..".simplify, tool, dtbFile, Nil
   makePlan cmdline inputs | runJob | getJobOutput
+
+#########################################################################
+# installFreedomDevicetreeTools allows wake flows to install
+# devicetree tools in customer deliveries and exclude all content which
+# does not directly contribute to the generation of customer BSP content.
+# It takes the following parameter
+#   - installPath: the path to install the generator in
+# For example, if you call `installFreedomDevicetreeTools freedom-e-sdk"`
+# the customer-relevant sources for devicetree tools will be found in
+#   freedom-e-sdk/freedom-devicetree-tools
+#########################################################################
+global target installFreedomDevicetreeTools installPath =
+  def generatorSources =
+    # The regex picks up file extensions for C++ and autotools
+    def extRegex = `.*\.(h,h\+\+,c,c\+\+,m4,am,in,ac)` 
+    # Include the README in installations
+    source "{here}/README.md",
+    # Include the relevant scripts installed by autoreconf -i
+    source "{here}/compile",
+    source "{here}/configure",
+    source "{here}/depcomp",
+    source "{here}/install-sh",
+    source "{here}/missing",
+    source "{here}/test-driver",
+    # Include the LICENSE files
+    sources here `LICENSE.*` ++
+    # Include all source code and autotools content by file extension
+    sources here                  extRegex ++
+    sources "{here}/m4"           extRegex ++
+    sources "{here}/bare_header"  extRegex ++
+    sources "{here}/metal_header" extRegex
+
+  mkdir installPath,
+  map (installIn installPath) generatorSources

--- a/build.wake
+++ b/build.wake
@@ -102,7 +102,7 @@ global def runFreedomBareHeaderGenerator options =
 global target installFreedomDevicetreeTools installPath =
   def generatorSources =
     # The regex picks up file extensions for C++ and autotools
-    def extRegex = `.*\.(h,h\+\+,c,c\+\+,m4,am,in,ac)` 
+    def extRegex = `.*\.(h|h\+\+|c|c\+\+|m4|am|in|ac)`
     # Include the README in installations
     source "{here}/README.md",
     # Include the relevant scripts installed by autoreconf -i

--- a/tests/test-wake-install.sh
+++ b/tests/test-wake-install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INSTALL_PATH="install-path"
+
+wake --init .
+
+wake -v "installFreedomDevicetreeTools \"${INSTALL_PATH}\""
+
+>&2 echo "$0: Checking for ${INSTALL_PATH}"
+if [ ! -d ${INSTALL_PATH} ] ; then
+        >&2 echo "$0: ERROR Failed to produce ${INSTALL_PATH}"
+        exit 1
+fi
+
+>&2 echo "$0: Checking for non-empty ${INSTALL_PATH}"
+if [ ! -f ${INSTALL_PATH}/freedom-devicetree-tools/README.md ] ; then
+        >&2 echo "$0: ERROR ${INSTALL_PATH} has bad contents"
+        exit 2
+fi
+
+cd ${INSTALL_PATH}/freedom-devicetree-tools && ./configure && make

--- a/tests/test-wake-install.sh
+++ b/tests/test-wake-install.sh
@@ -20,4 +20,4 @@ if [ ! -f ${INSTALL_PATH}/freedom-devicetree-tools/README.md ] ; then
         exit 2
 fi
 
-cd ${INSTALL_PATH}/freedom-devicetree-tools && ./configure && make
+cd ${INSTALL_PATH}/freedom-devicetree-tools && ./configure && make -j$(nproc)


### PR DESCRIPTION
`installFreedomDevicetreeTools` allows wake flows to install the source code for Devicetree Tools in customer deliveries and exclude all content which does not directly contribute to the generation of customer BSP content.