### PR TITLE
Add 'extern' to all declarations to allow -fno-common option

### DIFF
--- a/metal_header/device.c++
+++ b/metal_header/device.c++
@@ -247,15 +247,15 @@ std::string Device::platform_define_offset(node n, std::string suffix) {
  * "__metal_" namespace */
 void Device::emit_struct_decl(std::string type, const node &n) {
   emit_comment(n);
-  os << "struct __metal_driver_" << type << " __metal_dt_" << n.handle()
-     << ";\n\n";
+  os << "extern /* hello */ struct __metal_driver_" << type << " __metal_dt_"
+     << n.handle() << ";\n\n";
 }
 
 void Device::emit_struct_decl(std::string type, std::string suffix,
                               const node &n) {
   emit_comment(n);
-  os << "struct __metal_driver_" << type << "_" << suffix << " __metal_dt_"
-     << n.handle() << "_" << suffix << ";\n\n";
+  os << "extern /* hello */ struct __metal_driver_" << type << "_" << suffix
+     << " __metal_dt_" << n.handle() << "_" << suffix << ";\n\n";
 }
 
 void Device::emit_struct_begin(std::string type, const node &n) {

--- a/metal_header/memory.c++
+++ b/metal_header/memory.c++
@@ -25,7 +25,7 @@ void memory::include_headers() { os << "#include <metal/memory.h>\n"; }
 
 void memory::declare_structs() {
   auto declare = [&](node n) {
-    os << "struct metal_memory __metal_dt_mem_" << n.handle() << ";\n\n";
+    os << "extern struct metal_memory __metal_dt_mem_" << n.handle() << ";\n\n";
   };
 
   dtb.match(std::regex("sifive,sram0"), declare, std::regex("sifive,testram0"),

--- a/metal_header/riscv_cpu_intc.c++
+++ b/metal_header/riscv_cpu_intc.c++
@@ -16,7 +16,7 @@ string riscv_cpu_intc::handle(node n) {
 
 void riscv_cpu_intc::declare_structs() {
   dtb.match(std::regex(compat_string), [&](node n) {
-    os << "struct __metal_driver_riscv_cpu_intc __metal_dt_" << handle(n)
+    os << "extern struct __metal_driver_riscv_cpu_intc __metal_dt_" << handle(n)
        << ";\n\n";
   });
 }

--- a/metal_header/sifive_buserror0.c++
+++ b/metal_header/sifive_buserror0.c++
@@ -147,7 +147,7 @@ void sifive_buserror0::define_inlines() {
 void sifive_buserror0::declare_structs() {
   dtb.match(std::regex(compat_string), [&](node n) {
     emit_comment(n);
-    os << "struct metal_buserror"
+    os << "extern struct metal_buserror"
           " __metal_dt_"
        << n.handle() << ";\n\n";
   });

--- a/metal_header/sifive_rtc0.c++
+++ b/metal_header/sifive_rtc0.c++
@@ -177,8 +177,8 @@ void sifive_rtc0::define_inlines() {
 void sifive_rtc0::declare_structs() {
   dtb.match(std::regex(compat_string), [&](node n) {
     emit_comment(n);
-    os << "struct __metal_driver_sifive_rtc0 __metal_dt_rtc_" << n.instance()
-       << ";\n\n";
+    os << "extern struct __metal_driver_sifive_rtc0 __metal_dt_rtc_"
+       << n.instance() << ";\n\n";
   });
 }
 


### PR DESCRIPTION
-fno-common requires there to be only one definition of each global
symbol, with other usages being 'extern' declarations. This provides
compatibility with GCC 10 where -fno-common is now the default.

Signed-off-by: Keith Packard <keithp@keithp.com>