### PR TITLE
Removed unused L2PF defines.

### DIFF
--- a/metal_header/sifive_l2pf0.c++
+++ b/metal_header/sifive_l2pf0.c++
@@ -12,33 +12,3 @@ void sifive_l2pf0::include_headers() {
   dtb.match(std::regex(compat_string),
             [&](node n) { emit_include(compat_string); });
 }
-
-void sifive_l2pf0::create_defines() {
-  dtb.match(std::regex(compat_string), [&](node n) {
-    uint32_t val = 0;
-    /* Generate defines for L2 prefetch parameters  */
-
-    if (n.field_exists("sifive,spf-queue-entries")) {
-      val = n.get_fields<uint32_t>("sifive,spf-queue-entries")[0];
-    }
-    emit_def("METAL_SIFIVE_L2PF0_QUEUE_ENTRIES", std::to_string(val));
-
-    val = 0;
-    if (n.field_exists("sifive,spf-window-bits")) {
-      val = n.get_fields<uint32_t>("sifive,spf-window-bits")[0];
-    }
-    emit_def("METAL_SIFIVE_L2PF0_WINDOW_BITS", std::to_string(val));
-
-    val = 0;
-    if (n.field_exists("sifive,spf-distance-bits")) {
-      val = n.get_fields<uint32_t>("sifive,spf-distance-bits")[0];
-    }
-    emit_def("METAL_SIFIVE_L2PF0_DISTANCE_BITS", std::to_string(val));
-
-    val = 0;
-    if (n.field_exists("sifive,spf-streams")) {
-      val = n.get_fields<uint32_t>("sifive,spf-streams")[0];
-    }
-    emit_def("METAL_SIFIVE_L2PF0_STREAMS", std::to_string(val));
-  });
-}

--- a/metal_header/sifive_l2pf0.h
+++ b/metal_header/sifive_l2pf0.h
@@ -12,7 +12,6 @@ class sifive_l2pf0 : public Device {
 public:
   sifive_l2pf0(std::ostream &os, const fdt &dtb);
   void include_headers();
-  void create_defines();
 };
 
 #endif


### PR DESCRIPTION
Removed unused L2PF defines, since the latest l2pf dts node does not contain these parameters.
 