### PR TITLE
Fix bad register address for HCA DMA_DEST

### DIFF
--- a/bare_header/sifive_hca_0_5_x.h
+++ b/bare_header/sifive_hca_0_5_x.h
@@ -57,7 +57,7 @@ public:
       emit_offset("sifive,hca", "DMA_CR", 0x110);
       emit_offset("sifive,hca", "DMA_LEN", 0x114);
       emit_offset("sifive,hca", "DMA_SRC", 0x118);
-      emit_offset("sifive,hca", "DMA_DEST", 0x11C);
+      emit_offset("sifive,hca", "DMA_DEST", 0x120);
       emit_offset("sifive,hca", "HCA_REV", 0x200);
       emit_offset("sifive,hca", "AES_REV", 0x204);
       emit_offset("sifive,hca", "SHA_REV", 0x208);


### PR DESCRIPTION
Need to be merge in order to fix future issue with HCA (the current version of scl-metal did not use yet HCA DMA feature)