### PR TITLE
Use wake 'here' to make install path source location flexible

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -1,4 +1,4 @@
-def installDir ="build/freedom-devicetree-tools"
+def installDir = "build/freedom-devicetree-tools"
 global def freedomDevicetreeToolsInstallDir = installDir
 
 global def freedomDevicetreeToolsPath = "{installDir}/bin"

--- a/build.wake
+++ b/build.wake
@@ -1,5 +1,5 @@
-def installDir = simplify "build/{here}"
-global def freedomDevicetreeToolsInstallDir = "build/{here}"
+def installDir ="build/freedom-devicetree-tools"
+global def freedomDevicetreeToolsInstallDir = installDir
 
 global def freedomDevicetreeToolsPath = "{installDir}/bin"
 
@@ -11,7 +11,7 @@ global target freedomDevicetreeToolsInstall Unit =
     "--configure-args=",
     "--install-dir={relative runDir installDir}",
     Nil
-  def inputs = mkdir installDir, sources here `.*\.(c|c\+\+|cpp|h|h\+\+|hpp)`
+  def inputs = mkdir installDir, sources here `.*`
   def foutputs _ = files installDir `.*`
 
   makePlan cmdline inputs
@@ -119,6 +119,9 @@ global target installFreedomDevicetreeTools installPath =
     sources "{here}/m4"           extRegex ++
     sources "{here}/bare_header"  extRegex ++
     sources "{here}/metal_header" extRegex
-
+  def installWithStructure dir file =
+    def oneDown = simplify "{here}/.."
+    def into = "{dir}/{relative oneDown file.getPathName}"
+    installAs into file
   mkdir installPath,
-  map (installIn installPath) generatorSources
+  map (installWithStructure installPath) generatorSources

--- a/build.wake
+++ b/build.wake
@@ -11,7 +11,7 @@ global target freedomDevicetreeToolsInstall Unit =
     "--configure-args=",
     "--install-dir={relative runDir installDir}",
     Nil
-  def inputs = mkdir installDir, sources here `.*`
+  def inputs = mkdir installDir, sources here `.*\.(c|c\+\+|cpp|h|h\+\+|hpp)`
   def foutputs _ = files installDir `.*`
 
   makePlan cmdline inputs


### PR DESCRIPTION
`installIn` is defined as 
```
export def installIn dir file =
  installAs "{dir}/{file.getPathName}" file
```

When used with Wit, the `getPathName` would include only the repository name, for example:
```
installIn "builddir" pathToSomeFile -> builddir/freedom-devicetree-tools/somefile.sh
```
When the wake rule is used via git submodules a longer path is inserted, for example
```
installIn "builddir" pathToSomeFile -> builddir/freedom-e-sdk/software/freedom-devicetree-tools/somefile.sh
```
This PR aims to resolve the inconsistency by using `here/..` to capture the repository name directly, thus preserving the paths in `builddir`