### PR TITLE
[ESAT-360]: fix issue on clock frequency multiple redefinition

### DIFF
--- a/bare_header/fixed_clock.h
+++ b/bare_header/fixed_clock.h
@@ -16,8 +16,11 @@ public:
   void emit_defines() {
     dtb.match(std::regex(compat_string), [&](node n) {
       emit_comment(n);
+      std::string handle;
+      handle = n.handle();
+      std::transform(handle.begin(), handle.end(), handle.begin(), toupper);
 
-      emit_property_u32(n, METAL_CLOCK_FREQUENCY_LABEL,
+      emit_property_u32(n, handle + "_" + METAL_CLOCK_FREQUENCY_LABEL,
                         n.get_field<uint32_t>("clock-frequency"));
 
       os << std::endl;

--- a/fdt.c++
+++ b/fdt.c++
@@ -8,8 +8,8 @@
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
-#include <string>
 #include <map>
+#include <string>
 #include <sys/stat.h>
 #include <unistd.h>
 

--- a/fdt.c++
+++ b/fdt.c++
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <fstream>
 #include <string>
+#include <map>
 #include <sys/stat.h>
 #include <unistd.h>
 

--- a/metal_header/fixed_clock.c++
+++ b/metal_header/fixed_clock.c++
@@ -39,20 +39,23 @@ void fixed_clock::declare_inlines() {
 void fixed_clock::define_inlines() {
   Inline *rate_func;
   std::list<Inline *> extern_inlines;
-
   int count = 0;
+
   dtb.match(std::regex(compat_string), [&](node n) {
+    std::string handle;
+    handle = n.handle();
+    std::transform(handle.begin(), handle.end(), handle.begin(), toupper);
     if (count == 0) {
       rate_func = create_inline_def(
           "rate", "unsigned long",
           "(uintptr_t)clock == (uintptr_t)&__metal_dt_" + n.handle(),
-          platform_define(n, METAL_CLOCK_FREQUENCY_LABEL),
+          platform_define(n, handle + "_" + METAL_CLOCK_FREQUENCY_LABEL),
           "const struct metal_clock *clock");
     }
     if (count > 0) {
       add_inline_body(
           rate_func, "(uintptr_t)clock == (uintptr_t)&__metal_dt_" + n.handle(),
-          platform_define(n, METAL_CLOCK_FREQUENCY_LABEL));
+          platform_define(n, handle + "_" + METAL_CLOCK_FREQUENCY_LABEL));
     }
     if ((count + 1) == num_clocks) {
       add_inline_body(rate_func, "else", "0");


### PR DESCRIPTION
This intends to fix ESAT-360. Invalid parsing of dts file cause invalid definition of METAL_FIXED_CLOCK__CLOCK_FREQUENCY (which is in fact due to multiple redefinition).