### PR TITLE
Using attribute to declare function or variable with weak linkage.

### DIFF
--- a/metal_header/device.c++
+++ b/metal_header/device.c++
@@ -189,8 +189,8 @@ void Device::emit_inline_def(Inline *func, std::string device) {
 
 void Device::emit_struct_pointer_begin(std::string type, std::string name,
                                        std::string ext) {
-  os << "__asm__ (\".weak " << name << "\");\n";
-  os << "struct __metal_driver_" << type << " *" << name << ext << " = {\n";
+  os << "struct __metal_driver_" << type << " *" << name << ext
+     << " __attribute__((weak))  = {\n";
 }
 void Device::emit_struct_pointer_element(std::string type, uint32_t id,
                                          std::string field,
@@ -373,9 +373,8 @@ void Device::emit_struct_end(void) { os << "};\n\n"; }
 void Device::emit_struct_array_def_begin(std::string type, std::string name,
                                          std::string size) {
   os << "/* Custom array definition */\n";
-  os << "__asm__ (\".weak __metal_dt_" << name << "\");\n";
   os << "struct __metal_driver_" << type << " __metal_dt_" << name
-     << "[ ] = {\n";
+     << "[ ] __attribute__((weak)) = {\n";
 }
 
 void Device::emit_struct_array_elem_node(const node &n) {

--- a/metal_header/memory.c++
+++ b/metal_header/memory.c++
@@ -106,8 +106,8 @@ void memory::define_structs() {
 void memory::create_handles() {
   emit_def("__METAL_DT_MAX_MEMORIES", std::to_string(num_memories));
 
-  os << "__asm__ (\".weak __metal_memory_table\");\n";
-  os << "struct metal_memory *__metal_memory_table[] = {\n";
+  os << "struct metal_memory *__metal_memory_table[]"
+     << " __attribute__((weak)) = {\n";
 
   int i = 0;
   auto emit = [&](node n) {


### PR DESCRIPTION
 - Using `__asm__ (".weak xxx"); int xxx;` is hack way to declare a
   variable is weak symbol, and clang/LLVM will emit an error for that.