### PR TITLE
Prevent generating empty metal_buserror struct

### DIFF
--- a/metal_header/sifive_buserror0.c++
+++ b/metal_header/sifive_buserror0.c++
@@ -160,7 +160,8 @@ void sifive_buserror0::define_structs() {
     emit_comment(n);
     os << "struct metal_buserror"
           " __metal_dt_"
-       << n.handle() << " = {\n";
+       << n.handle() << " = {\n"
+          "\t.__no_empty_structs = 0,\n";
 
     /* Emit struct fields here */
 

--- a/metal_header/sifive_buserror0.c++
+++ b/metal_header/sifive_buserror0.c++
@@ -160,7 +160,8 @@ void sifive_buserror0::define_structs() {
     emit_comment(n);
     os << "struct metal_buserror"
           " __metal_dt_"
-       << n.handle() << " = {\n"
+       << n.handle()
+       << " = {\n"
           "\t.__no_empty_structs = 0,\n";
 
     /* Emit struct fields here */


### PR DESCRIPTION
This prevent 'ISO C forbids empty initializer braces [-Werror=pedantic]'
error.

Signed-off-by: Frank Chang <frank.chang@sifive.com>