### PR TITLE
Remove 'fu540-c000,l2' compatible

### DIFF
--- a/bare_header/sifive_ccache0.h
+++ b/bare_header/sifive_ccache0.h
@@ -11,7 +11,7 @@
 class sifive_ccache0 : public Device {
 public:
   sifive_ccache0(std::ostream &os, const fdt &dtb)
-      : Device(os, dtb, "sifive,(ccache0|fu540-c000,l2)") {}
+      : Device(os, dtb, "sifive,ccache0") {}
 
   int get_index(const node &n) { return Device::get_index(n, compat_string); }
 

--- a/metal_header/sifive_ccache0.c++
+++ b/metal_header/sifive_ccache0.c++
@@ -6,7 +6,7 @@
 #include <regex>
 
 sifive_ccache0::sifive_ccache0(std::ostream &os, const fdt &dtb)
-    : Device(os, dtb, "sifive,(ccache0|fu540-c000,l2)") {}
+    : Device(os, dtb, "sifive,ccache0") {}
 
 void sifive_ccache0::include_headers() {
   dtb.match(std::regex(compat_string),

--- a/tests/sifive-hifive-unleashed/core.dts
+++ b/tests/sifive-hifive-unleashed/core.dts
@@ -164,7 +164,7 @@
 			clock-output-names = "xtal";
 		};
 		prci: prci@10000000 {
-			compatible = "sifive,ux00prci0";
+			compatible = "sifive,fu540-c000-prci0";
 			reg = <0x0 0x10000000 0x0 0x1000>;
 			reg-names = "control";
 			clocks = <&refclk>;
@@ -194,7 +194,7 @@
 			cache-sets = <2048>;
 			cache-size = <2097152>;
 			cache-unified;
-			compatible = "sifive,fu540-c000,l2", "cache";
+			compatible = "sifive,ccache0", "cache";
 			interrupt-parent = <&L4>;
 			interrupts = <1 2 3>;
 			next-level-cache = <&L25 &L40 &L36>;
@@ -435,6 +435,8 @@
 		};
 		L45: pwm@10020000 {
 			compatible = "sifive,pwm0";
+			sifive,comparator-widthbits = <16>;
+			sifive,ncomparators = <4>;
 			interrupt-parent = <&L4>;
 			interrupts = <42 43 44 45>;
 			reg = <0x0 0x10020000 0x0 0x1000>;
@@ -445,6 +447,8 @@
 		};
 		L46: pwm@10021000 {
 			compatible = "sifive,pwm0";
+			sifive,comparator-widthbits = <16>;
+			sifive,ncomparators = <4>;
 			interrupt-parent = <&L4>;
 			interrupts = <46 47 48 49>;
 			reg = <0x0 0x10021000 0x0 0x1000>;


### PR DESCRIPTION
We currently use ccache0 compatible in DT file of both Unleashed and Unmatched. It align with Federation, so we don't need to parse "sifive,fu540-c000,l2" anymore.